### PR TITLE
DEV-1893 Replace URL for production API

### DIFF
--- a/api/hmf_api_get
+++ b/api/hmf_api_get
@@ -33,12 +33,10 @@ query=$1 && shift
 
 # no default for api credentials and url to avoid using wrong env as much as possible
 if [[ "${environment}" == "prod" ]]; then
-    api_crt="${api_dir}/api.crt"
-    api_key="${api_dir}/api.key"
-    api_url="https://api.hartwigmedicalfoundation.nl/hmf/v1"
+    api_url="http://api.prod-1/hmf/v1"
 elif [[ "${environment}" == "acc" ]]; then
-    api_crt="${api_dir}/acc/api.crt"
-    api_key="${api_dir}/acc/api.key"
+    api_crt="--cert ${api_dir}/acc/api.crt"
+    api_key="--key ${api_dir}/acc/api.key"
     api_url="https://api.acc.hartwigmedicalfoundation.nl/hmf/v1"
 else
     die "Environment should be either prod or acc"
@@ -72,8 +70,7 @@ main () {
 
 api_curl () {
     local url=$1 && shift
-    curl --fail --silent --show-error --cert "${api_crt}" --key "${api_key}" \
-    -H "Content-Type: application/json" -X GET "${url}"
+    curl --fail --silent --show-error ${api_crt} ${api_key} -H "Content-Type: application/json" -X GET "${url}"
 }
 
 main

--- a/api/hmf_api_patch
+++ b/api/hmf_api_patch
@@ -50,12 +50,10 @@ fi
 
 # no default for api credentials and url to avoid using wrong env as much as possible
 if [[ "${environment}" == "prod" ]]; then
-    api_crt="${api_dir}/api.crt"
-    api_key="${api_dir}/api.key"
-    api_url="https://api.hartwigmedicalfoundation.nl/hmf/v1"
+    api_url="http://api.prod-1/hmf/v1"
 elif [[ "${environment}" == "acc" ]]; then
-    api_crt="${api_dir}/acc/api.crt"
-    api_key="${api_dir}/acc/api.key"
+    api_crt="--cert ${api_dir}/acc/api.crt"
+    api_key="--key ${api_dir}/acc/api.key"
     api_url="https://api.acc.hartwigmedicalfoundation.nl/hmf/v1"
 else
     die "Environment should be either prod or acc"
@@ -127,20 +125,20 @@ get_name_from_object () {
 get_with_curl () {
     local object_location=$1 && shift
     curl -f --silent --show-error -H "Content-Type: application/json" \
-    --cert-type pem --cert "${api_crt}" --key "${api_key}" -X GET "${api_url}/${object_location}"
+      --cert-type pem ${api_crt} ${api_key} -X GET "${api_url}/${object_location}"
 }
 
 patch_with_curl () {
     local object_location=$1 && shift
     local data=$1 && shift
     curl --silent --show-error -H "Content-Type: application/json" -H "Accept: application/json" \
-     --cert-type pem --cert "${api_crt}" --key "${api_key}" -X PATCH "${api_url}/${object_location}" --data "${data}" > /dev/null
+      --cert-type pem ${api_crt} ${api_key} -X PATCH "${api_url}/${object_location}" --data "${data}" > /dev/null
 }
 
 post_with_curl_without_data () {
     local object_location=$1 && shift
     curl --silent --show-error \
-     --cert-type pem --cert "${api_crt}" --key "${api_key}" -X POST "${api_url}/${object_location}" > /dev/null
+      --cert-type pem ${api_crt} ${api_key} -X POST "${api_url}/${object_location}" > /dev/null
 }
 
 main

--- a/api/patch_api_sample_q30_yld_from_source_sample
+++ b/api/patch_api_sample_q30_yld_from_source_sample
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-api_url="https://api.hartwigmedicalfoundation.nl/hmf/v1"
-api_cred_dir="/data/common/dbs/api_credentials"
-api_key_file="${api_cred_dir}/api.key"
-api_crt_file="${api_cred_dir}/api.crt"
+api_url="http://api.prod-1/hmf/v1"
 
 if [[ "$#" -ne 2 ]]; then
     echo "-----"
@@ -55,7 +52,7 @@ main () {
 ## Generic api function
 hmfapi () {
     echo "$@" 1>&2
-    http --ignore-stdin --cert="${api_crt_file}" --cert-key="${api_key_file}" "$@"
+    http --ignore-stdin "$@"
 }
 
 main

--- a/api/update_api_db_jsons
+++ b/api/update_api_db_jsons
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 
 JSON_DIR="/data/ops/api/prod/database"
-CRED_DIR="/data/common/dbs/api_credentials"
-CRT_FILE="${CRED_DIR}/api.crt"
-KEY_FILE="${CRED_DIR}/api.key"
-BASE_URL="https://api.hartwigmedicalfoundation.nl/hmf/v1"
+BASE_URL="http://api.prod-1/hmf/v1"
 LOG_FILE="${JSON_DIR}/update_api_db.log"
 DATETIME=$(date)
 
 DB_TYPES=( fastq entities runs samples sets flowcells inis shares stacks platforms sequencers biopsies )
-
-if [[ ! -f "${CRT_FILE}" ]]; then echo "[ERROR] CRT file not found (${CRT_FILE})" && exit 1; fi
-if [[ ! -f "${KEY_FILE}" ]]; then echo "[ERROR] KEY file not found (${KEY_FILE})" && exit 1; fi
 
 ## In case tmp files do exist but are older than 30 min (cmin param)
 ## then assume previous execution to have timed out and continue anyway
@@ -32,9 +26,6 @@ for TYPE in "${DB_TYPES[@]}"; do
     OUTPUT_FILE_TMP="${JSON_DIR}/tmp_${TYPE}.json.tmp"
 
     curl \
-        --cert-type pem \
-        --cert "${CRT_FILE}" \
-        --key "${KEY_FILE}" \
         -X GET \
         -H "Accept: application/json" \
         -H "Content-Type: application/json" \

--- a/datarequest/scripts/add_researcher_to_colo_data_gcp
+++ b/datarequest/scripts/add_researcher_to_colo_data_gcp
@@ -22,10 +22,8 @@ if [[ -z "${gcp_mail}" ]]; then
     print_usage
 fi
 
-api_url=$"https://api.hartwigmedicalfoundation.nl"
+api_url=$"http://api.prod-1"
 api_url_spec=$"${api_url}/hmf/v1"
-api_key=$"/data/common/dbs/api_credentials/api.key"
-api_cert=$"/data/common/dbs/api_credentials/api.crt"
 bucket_name="hmf-dr-colo"
 
 
@@ -86,12 +84,12 @@ echo ""
 echo "[INFO] ADD $gcp_mail to API GROUP (for ACL permissions) RELATED TO ${bucket_name} ."
 echo ""
 echo "[INFO] Current accounts in API group related to ${bucket_name} :"
-account_nrs=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
+account_nrs=$( curl -s ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
 email_in_acl_group=$""
 for account_nr in $account_nrs
 do
-    curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
-    email_acl=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//' )
+    curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
+    email_acl=$( curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//' )
     email_in_acl_group+=${email_acl}
 done
 echo ""
@@ -100,12 +98,12 @@ for email in $(echo ${gcp_mail} | sed "s/,/ /g")
 do
     if [[ $( echo ${email_in_acl_group} | grep $email ) == "" ]]; then
         echo "....Adding $email to API group  ...."
-        if [[ $( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts | grep $email ) == "" ]]; then
-            account_id=$( curl -s --cert ${api_cert} --key ${api_key} -d '{"email": "'$email'"}' -H "Content-Type: application/json" -X POST ${api_url_spec}/accounts | jq .[] )
+        if [[ $( curl -s ${api_url_spec}/accounts | grep $email ) == "" ]]; then
+            account_id=$( curl -s -d '{"email": "'$email'"}' -H "Content-Type: application/json" -X POST ${api_url_spec}/accounts | jq .[] )
         else
-            account_id=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts | jq --arg email_select "$email" '.[] | select(.email==$email_select) | .id' )
+            account_id=$( curl -s ${api_url_spec}/accounts | jq --arg email_select "$email" '.[] | select(.email==$email_select) | .id' )
         fi
-        curl -s --cert ${api_cert} --key ${api_key} -d '{"group_id": "$group_id", "account_id": '$account_id'}' -H "Content-Type: application/json" -X POST ${api_url_spec}/groups/${group_id}/members
+        curl -s -d '{"group_id": "$group_id", "account_id": '$account_id'}' -H "Content-Type: application/json" -X POST ${api_url_spec}/groups/${group_id}/members
         echo ""
     else
         echo "[ERROR] Account $email already present in API group related to ${bucket_name} , so no adding needed."
@@ -114,22 +112,22 @@ do
 done
 
 echo "[INFO] Updated accounts in API group related to ${bucket_name} :"
-account_nrs=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
+account_nrs=$( curl -s ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
 for account_nr in $account_nrs
 do
-    curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
+    curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
 done
 echo ""
 
 echo "[INFO] Current number of raw files with API group related to ${bucket_name}  in the ACL:"
-curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l
-number=$(expr $( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l ) - 1)
+curl -s ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l
+number=$(expr $( curl -s ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l ) - 1)
 echo "[INFO] Links to be shared with researcher:"
 echo "URL Bucket = gs://${bucket_name}/"
 echo "URLs to raw data files:"
 for i in $(seq 0 $number); do
-    file_number=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/files | jq ".[${i}].file_id" )
-    curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/files/${file_number} | jq -r '.filepath'
+    file_number=$( curl -s ${api_url_spec}/groups/${group_id}/files | jq ".[${i}].file_id" )
+    curl -s ${api_url_spec}/files/${file_number} | jq -r '.filepath'
 done
 echo ""
 echo "[INFO] If you eventually want to revoke access use the script revoke_access_data_GCP with '-i DR-colo' (but never remove the API group!!)."

--- a/datarequest/scripts/add_researcher_to_data_gcp
+++ b/datarequest/scripts/add_researcher_to_data_gcp
@@ -25,10 +25,8 @@ if [[ -z "${dr_id}" || -z "${gcp_mail}" ]]; then
 fi
 
 
-api_url=$"https://api.hartwigmedicalfoundation.nl"
+api_url=$"http://api-prod1"
 api_url_spec=$"${api_url}/hmf/v1"
-api_key=$"/data/common/dbs/api_credentials/api.key"
-api_cert=$"/data/common/dbs/api_credentials/api.crt"
 
 
 ## quick input checks
@@ -96,7 +94,7 @@ gsutil -u hmf-share iam get gs://${bucket_name}/
 echo ""
 
 
-group_id=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups | jq --arg release_id "$release_id" '.[] | select(.name==$release_id) | .id')
+group_id=$( curl -s ${api_url_spec}/groups | jq --arg release_id "$release_id" '.[] | select(.name==$release_id) | .id')
 if [[ "${group_id}" == "" ]]; then
     echo "[INFO] NO API GROUP (for ACL permissions) RELATED TO: ${release_id}."
 else
@@ -104,12 +102,12 @@ else
     echo "[INFO] ADD $gcp_mail to API GROUP (for ACL permissions) RELATED TO: ${release_id}."
     echo ""
     echo "[INFO] Current accounts in API group related to ${release_id}:"
-    account_nrs=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
+    account_nrs=$( curl -s ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
     email_in_acl_group=$""
     for account_nr in $account_nrs
     do
-        curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
-        email_acl=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//' )
+        curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
+        email_acl=$( curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//' )
         email_in_acl_group+=${email_acl}
     done
     echo ""
@@ -118,12 +116,12 @@ else
     do
         if [[ $( echo ${email_in_acl_group} | grep $email ) == "" ]]; then
             echo "....Adding $email to API group  ...."
-            if [[ $( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts | grep $email ) == "" ]]; then
-                account_id=$( curl -s --cert ${api_cert} --key ${api_key} -d '{"email": "'$email'"}' -H "Content-Type: application/json" -X POST ${api_url_spec}/accounts | jq .[] )
+            if [[ $( curl -s ${api_url_spec}/accounts | grep $email ) == "" ]]; then
+                account_id=$( curl -s -d '{"email": "'$email'"}' -H "Content-Type: application/json" -X POST ${api_url_spec}/accounts | jq .[] )
             else
-                account_id=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts | jq --arg email_select "$email" '.[] | select(.email==$email_select) | .id' )
+                account_id=$( curl -s ${api_url_spec}/accounts | jq --arg email_select "$email" '.[] | select(.email==$email_select) | .id' )
             fi
-            curl -s --cert ${api_cert} --key ${api_key} -d '{"group_id": "$group_id", "account_id": '$account_id'}' -H "Content-Type: application/json" -X POST ${api_url_spec}/groups/${group_id}/members
+            curl -s -d '{"group_id": "$group_id", "account_id": '$account_id'}' -H "Content-Type: application/json" -X POST ${api_url_spec}/groups/${group_id}/members
             echo ""
         else
             echo "[ERROR] Account $email already present in API group related to ${release_id}, so no adding needed."
@@ -132,15 +130,15 @@ else
     done
 
     echo "[INFO] Updated accounts in API group related to ${release_id}:"
-    account_nrs=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
+    account_nrs=$( curl -s ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
     for account_nr in $account_nrs
     do
-        curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
+        curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
     done
     echo ""
 
     echo "[INFO] Current number of raw files with API group related to ${release_id} in the ACL:"
-    curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l
+    curl -s ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l
     echo ""
 fi
 

--- a/datarequest/scripts/check_gcp_manifest_with_metadata
+++ b/datarequest/scripts/check_gcp_manifest_with_metadata
@@ -30,10 +30,8 @@ fi
 echo ""
 echo "[START] check_gcp_manifest_with_metadata: $(date +"%y%m%d (%T)")"
 
-api_url=$"https://api.hartwigmedicalfoundation.nl"
+api_url=$"http://api.prod-1"
 api_url_spec=$"${api_url}/hmf/v1"
-api_key=$"/data/common/dbs/api_credentials/api.key"
-api_cert=$"/data/common/dbs/api_credentials/api.crt"
 
 # make dir for temporary files
 mkdir temp_GCP_check
@@ -102,15 +100,15 @@ if [[ ${number_files_manifest} > 0 ]]; then
     echo '[INFO] NUMBER OF RAW DATA FILES WITH REQUESTER ACCOUNT(S) IN ACL:'
     dr_id=$( jq '.id' ${manifest_json} | sed 's/"//g' )
     dr_name="DR-${dr_id}"
-    group_id=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups | jq --arg dr_name "$dr_name" '.[] | select(.name==$dr_name) | .id')
-    curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l
+    group_id=$( curl -s ${api_url_spec}/groups | jq --arg dr_name "$dr_name" '.[] | select(.name==$dr_name) | .id')
+    curl -s ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l
     echo "---Accounts related to group---:"
-    account_nrs=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
+    account_nrs=$( curl -s ${api_url_spec}/groups/${group_id}/members | jq '.[] | .account_id' )
     for account_nr in $account_nrs
     do
-        curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
+        curl -s ${api_url_spec}/accounts/${account_nr} | jq '.email' | sed -e 's/^"//' -e 's/"$//'
     done
-    number_files_gcp=$( curl -s --cert ${api_cert} --key ${api_key} ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l)
+    number_files_gcp=$( curl -s ${api_url_spec}/groups/${group_id}/files | jq . | grep file_id | wc -l)
     echo ""
     if [[ ${number_files_manifest} == ${number_files_gcp} ]]; then
         echo "[INFO] Number of files in manifest and number of files in GCP (with requester account(s) in ACL) are similar."

--- a/datarequest/scripts/create_datarequest_tool_cmd
+++ b/datarequest/scripts/create_datarequest_tool_cmd
@@ -26,7 +26,7 @@ if [[ -z "${dr_name}" || -z "${run_mode}" || -z "${gcp_mail}" ]]; then
     print_usage
 fi
 
-api_url="https://api.hartwigmedicalfoundation.nl"
+api_url="http://api.prod-1"
 tool_jar_symlink="$(locate_prod_datarequest)"
 tool_jar="$(readlink -f "${tool_jar_symlink}")"
 api_keystore="/data/common/dbs/api_credentials/api.jks"

--- a/datarequest/scripts/revoke_access_data_gcp
+++ b/datarequest/scripts/revoke_access_data_gcp
@@ -25,10 +25,8 @@ if [[ -z "${dr_id}" || -z "${gcp_mail}" ]]; then
 fi
 
 
-api_url=$"https://api.hartwigmedicalfoundation.nl"
+api_url=$"http://api.prod-1"
 api_url_spec=$"${api_url}/hmf/v1"
-api_key=$"/data/common/dbs/api_credentials/api.key"
-api_cert=$"/data/common/dbs/api_credentials/api.crt" 
 
 
 ## quick input checks

--- a/gcp/gridss_file_locations
+++ b/gcp/gridss_file_locations
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 api_cred_dir="/data/common/dbs/api_credentials"
-api_crt_file="${api_cred_dir}/api.crt"
-api_key_file="${api_cred_dir}/api.key"
 
 latest_gridss_run_details () {
   local set=$1
@@ -24,7 +22,7 @@ latest_gridss_file_locations() {
   local set=$1
   local run_details=$(latest_gridss_run_details $set)
   local run_id=$(echo $run_details | cut -f 1 -d " ")
-  local file_data=$(curl -v --cert-type pem --cert ${api_crt_file} --key ${api_key_file} "https://api.hartwigmedicalfoundation.nl/hmf/v1/files?run_id=${run_id}")
+  local file_data=$(curl -v "http://api.prod-1/hmf/v1/files?run_id=${run_id}")
   local unfiltered_vcf=$(echo $file_data | jq -r '.[] | select(.filepath | endswith("vcf.gz")) | .filepath' | grep -P "gridss(.unfiltered)?.vcf.gz$" | uniq)
   if [[ $unfiltered_vcf == "" ]]; then
     unfiltered_vcf=$(echo $file_data | jq -r '.[] | select(.filepath | endswith("vcf.gz")) | .filepath' | grep -P "structural_caller/(.*).filter.final.vcf.gz$" | uniq)

--- a/ops/manual_fastq_register
+++ b/ops/manual_fastq_register
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 api_cred_dir="/data/common/dbs/api_credentials"
-api_crt="${api_cred_dir}/api.crt"
-api_key="${api_cred_dir}/api.key"
-api_url='https://api.hartwigmedicalfoundation.nl/hmf/v1'
+api_url='http://api.prod-1/hmf/v1'
 
 hmfapi () {
     http --ignore-stdin --cert="${api_crt}" --cert-key="${api_key}" "$@"
@@ -21,7 +19,7 @@ barcode=$1 && shift
 fastq_dir=$1 && shift
 
 sample_name=""
-sample_id=$(curl -s --cert-type pem --cert "${api_crt}" --key "${api_key}" "${api_url}/samples?barcode=${barcode}" | jq '.[].id')
+sample_id=$(curl -s "${api_url}/samples?barcode=${barcode}" | jq '.[].id')
 
 if [[ -z "${sample_id}" ]]; then
     echo "[ERROR] Barcode not found at API (${barcode})" && exit 1
@@ -49,6 +47,5 @@ done
 
 echo "[INFO] Registering sample"
 curl -s --header "Content-type: application/json" \
-    --cert-type pem -X PATCH \
-    --cert "${api_crt}" --key "${api_key}" \
+    -X PATCH \
     -d '{"name": "'${sample_name}'", "status": "Pending_QC"}' "${api_url}/samples/${sample_id}"

--- a/ops/register_set_by_json_to_prod
+++ b/ops/register_set_by_json_to_prod
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
 
 json=$1
-
-api_cred_dir="/data/common/dbs/api_credentials"
-api_crt_file="${api_cred_dir}/api.crt"
-api_key_file="${api_cred_dir}/api.key"
-api_url='https://api.hartwigmedicalfoundation.nl/hmf/v1/action/register'
+api_url='http://api.prod-1/hmf/v1/action/register'
 
 if [[ -z "${json+x}" ]]; then echo "[ERROR] No json given" && exit 1; fi
-if [[ ! -f "${api_crt_file}" ]]; then echo "[ERROR] File does not exist (${api_crt_file})" && exit 1; fi
-if [[ ! -f "${api_key_file}" ]]; then echo "[ERROR] File does not exist (${api_key_file})" && exit 1; fi
-if [[ ! -f "${json}" ]]; then echo "[ERROR] File does not exist (${json})" && exit 1; fi
-
-curl -s -v --cert-type pem --cert ${api_crt_file} --key ${api_key_file} ${api_url} -XPOST -H "Content-Type: application/json" -d @${json}
+curl -s ${api_url} -XPOST -H "Content-Type: application/json" -d @${json}

--- a/utilityscripts/create_aria2_config_by_set_name
+++ b/utilityscripts/create_aria2_config_by_set_name
@@ -11,9 +11,7 @@ fi
 api_cred_dir="/data/common/dbs/api_credentials"
 gcp_cred_dir="/data/common/dbs/gcp_credentials"
 
-api_url="https://api.hartwigmedicalfoundation.nl/hmf/v1"
-api_crt_file="${api_cred_dir}/api.crt"
-api_key_file="${api_cred_dir}/api.key"
+api_url="http://api.prod-1/hmf/v1"
 
 gcp_url_sign_script="generate_signed_gcp_url.py"
 gcp_key_file="${gcp_cred_dir}/hmf-ops"
@@ -74,8 +72,7 @@ function main() {
     done
 
     ## get the file objects for one run by id
-    files_json=$(curl --silent --cert-type pem \
-        --cert ${api_crt_file} --key ${api_key_file} -X GET \
+    files_json=$(curl --silent -X GET \
         -H "Accept: application/json" -H "Content-Type: application/json" \
         "${files_api_url}")
 


### PR DESCRIPTION
We are planning to switch to an instance of the API that is no longer
exposed via the public Internet (and thus does not require API
certificates).