### PR TITLE
DEV-2157 Try shortening bashrc

### DIFF
--- a/config/bashrc
+++ b/config/bashrc
@@ -1,16 +1,4 @@
-export SCRIPTS=/data/common/repos/scripts
-export PATH=${SCRIPTS}/functions:$PATH
-export PATH=${SCRIPTS}/functions/test:$PATH
-export PATH=${SCRIPTS}/datarequest/procedure:$PATH
-export PATH=${SCRIPTS}/datarequest/scripts:$PATH
-export PATH=${SCRIPTS}/sql/execution:$PATH
-for d in analysisscripts api bam chord crunch cuplr datacleanup datarequest gcp lims nas ops snpcheck utilityscripts validation
-do
-   export PATH="${SCRIPTS}/${d}"
-done 
-for d in bachelor bamslicer gridss healthchecker idgenerator patientdb patientreporter purityploidyestimator sage sigs svlinx \
-    svloader 
-do
-   export PATH="${SCRIPTS}/hmftools/${d}" 
+for d in $(find /data/common/repos/scripts/* -type d | grep -v '.git'); do
+    export PATH="${PATH}:$d"
 done
 

--- a/config/bashrc
+++ b/config/bashrc
@@ -1,33 +1,16 @@
 export SCRIPTS=/data/common/repos/scripts
-export PATH=${SCRIPTS}/api:$PATH
-export PATH=${SCRIPTS}/gcp:$PATH
-export PATH=${SCRIPTS}/ops:$PATH
-export PATH=${SCRIPTS}/bam:$PATH
-export PATH=${SCRIPTS}/nas:$PATH
-export PATH=${SCRIPTS}/crunch:$PATH
-export PATH=${SCRIPTS}/lims:$PATH
-export PATH=${SCRIPTS}/snpcheck:$PATH
-export PATH=${SCRIPTS}/utilityscripts:$PATH
-export PATH=${SCRIPTS}/analysisscripts:$PATH
 export PATH=${SCRIPTS}/functions:$PATH
 export PATH=${SCRIPTS}/functions/test:$PATH
-export PATH=${SCRIPTS}/hmftools/healthchecker:$PATH
-export PATH=${SCRIPTS}/hmftools/bamslicer:$PATH
-export PATH=${SCRIPTS}/hmftools/patientdb:$PATH
-export PATH=${SCRIPTS}/hmftools/patientreporter:$PATH
-export PATH=${SCRIPTS}/hmftools/purityploidyestimator:$PATH
-export PATH=${SCRIPTS}/hmftools/idgenerator:$PATH
-export PATH=${SCRIPTS}/hmftools/gridss:$PATH
-export PATH=${SCRIPTS}/hmftools/sage:$PATH
-export PATH=${SCRIPTS}/hmftools/bachelor:$PATH
-export PATH=${SCRIPTS}/hmftools/svloader:$PATH
-export PATH=${SCRIPTS}/hmftools/svlinx:$PATH
-export PATH=${SCRIPTS}/hmftools/sigs:$PATH
-export PATH=${SCRIPTS}/chord:$PATH
-export PATH=${SCRIPTS}/cuplr:$PATH
 export PATH=${SCRIPTS}/datarequest/procedure:$PATH
 export PATH=${SCRIPTS}/datarequest/scripts:$PATH
-export PATH=${SCRIPTS}/datarequest:$PATH
 export PATH=${SCRIPTS}/sql/execution:$PATH
-export PATH=${SCRIPTS}/validation:$PATH
-export PATH=${SCRIPTS}/datacleanup:$PATH
+for d in analysisscripts api bam chord crunch cuplr datacleanup datarequest gcp lims nas ops snpcheck utilityscripts validation
+do
+   export PATH="${SCRIPTS}/${d}"
+done 
+for d in bachelor bamslicer gridss healthchecker idgenerator patientdb patientreporter purityploidyestimator sage sigs svlinx \
+    svloader 
+do
+   export PATH="${SCRIPTS}/hmftools/${d}" 
+done
+


### PR DESCRIPTION
Maybe this is easier to read? I dunno. Another possibility could be just to add every directory under the top-level and `hmftools` directories, even though this would add some that we wouldn't want it would maybe be just as functional and much shorter:

```
# for d in $(find ${SCRIPTS} -type d -maxdepth 1) $(find ${SCRIPTS}/hmftools -type d -maxdepth 1); do
  export PATH=...
```
