### PR TITLE
DEV-2377 Use generated shared TSV temporarily

### DIFF
--- a/turquoise/report_date.sh
+++ b/turquoise/report_date.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-input_file="/data/ops/lims/prod/final_sharing_db.tsv"
+input_file="/data/ops/lims/prod/sharing_db_generated.tsv"
 wd="$HOME/.turquoise/data"
 out_dir="$HOME/.turquoise"
 


### PR DESCRIPTION
We should move to calling the endpoint directly but this hasn't happened
yet so use the generated TSV (which is created from the data in the
endpoint) for now.

The output from old and new inputs has been checked on the ops-vm and
the new output looks reasonable.