### PR TITLE
DEV-2438 Avoid syncing LIMS logs

### DIFF
--- a/gcp/sync_clinicaldb_resources_to_gcp
+++ b/gcp/sync_clinicaldb_resources_to_gcp
@@ -10,7 +10,8 @@ info "Syncing clinicaldb resources to GCP"
 gsutil cp /data/ecrf/cpct_ecrf.xml ${BUCKET}/cpct_ecrf.xml
 gsutil cp /data/ecrf/cpct_form_status.csv ${BUCKET}/cpct_form_status.csv 
 gsutil cp /data/ecrf/drup_ecrf.xml ${BUCKET}/drup_ecrf.xml
-gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/ops/lims/prod/* ${BUCKET}/lims
+gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/ops/lims/prod/*.tsv ${BUCKET}/lims/
+gsutil cp /data/ops/lims/prod/lims.json ${BUCKET}/lims/
 gsutil cp /data/dbs/disease_ontology/201015_doid.json ${BUCKET}/201015_doid.json
 gsutil cp /data/dbs/clinical_curation/tumor_location_mapping.tsv ${BUCKET}/tumor_location_mapping.tsv 
 gsutil cp /data/dbs/clinical_curation/treatment_mapping.tsv ${BUCKET}/treatment_mapping.tsv 

--- a/gcp/sync_data_vm_resources_to_gcp
+++ b/gcp/sync_data_vm_resources_to_gcp
@@ -4,6 +4,7 @@ set -e
 source message_functions || exit 1
 
 BUCKET="gs://data-vm-resources-prod-1"
+FASTCP="gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp"
 
 info "Syncing data-vm resources to GCP"
 gsutil cp /data/dbs/clinical_data/curated_primary_tumor.tsv ${BUCKET}/dbs/clinical_data/curated_primary_tumor.tsv
@@ -12,9 +13,10 @@ gsutil cp /data/dbs/summary_patient_report/summary_samples.tsv ${BUCKET}/dbs/sum
 gsutil cp /data/dbs/virus_interpreter/taxonomy_db.tsv ${BUCKET}/dbs/virus_interpreter/taxonomy_db.tsv
 gsutil cp /data/dbs/virus_interpreter/virus_interpretation.tsv ${BUCKET}/dbs/virus_interpreter/virus_interpretation.tsv
 gsutil cp /data/dbs/virus_interpreter/virus_blacklist.tsv ${BUCKET}/dbs/virus_interpreter/virus_blacklist.tsv
-gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/ops/lims/prod/* ${BUCKET}/ops/lims/prod/
-gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/dbs/clinical_curation/* ${BUCKET}/ops/clinical_curation/
-gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/ecrf/* ${BUCKET}/ecrf/
+$FASTCP /data/ops/lims/prod/*.tsv ${BUCKET}/ops/lims/prod/
+gsutil cp /data/ops/lims/prod/lims.json ${BUCKET}/ops/lims/prod/
+$FASTCP /data/dbs/clinical_curation/* ${BUCKET}/ops/clinical_curation/
+$FASTCP /data/ecrf/* ${BUCKET}/ecrf/
 gsutil cp /data/dbs/patient_reporter_images/* ${BUCKET}/dbs/patient_reporter_images/
 gsutil cp /data/dbs/disease_ontology/201015_doid.json ${BUCKET}/dbs/disease_ontology/201015_doid.json
 gsutil cp /data/dbs/summary_patient_report/summary_samples.tsv ${BUCKET}/dbs/summary_patient_report/summary_samples.tsv

--- a/gcp/sync_patient_reporter_resources_to_gcp
+++ b/gcp/sync_patient_reporter_resources_to_gcp
@@ -12,6 +12,7 @@ gsutil cp /data/dbs/summary_patient_report/summary_samples.tsv ${BUCKET}/sample_
 gsutil cp /data/dbs/virus_interpreter/taxonomy_db.tsv ${BUCKET}/taxonomy_db.tsv
 gsutil cp /data/dbs/virus_interpreter/virus_interpretation.tsv ${BUCKET}/virus_interpretation.tsv
 gsutil cp /data/dbs/virus_interpreter/virus_blacklist.tsv ${BUCKET}/virus_blacklist.tsv
-gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/ops/lims/prod/* ${BUCKET}/lims
+gsutil -m -o GSUtil:parallel_process_count=7 -o GSUtil:parallel_thread_count=1 cp /data/ops/lims/prod/*.tsv ${BUCKET}/lims/
+gsutil cp /data/ops/lims/prod/lims.json ${BUCKET}/lims/
 gsutil cp /data/dbs/patient_reporter_images/* ${BUCKET}/
 info "Done syncing patient-reporter resources"


### PR DESCRIPTION
We are having intermittent problems to do with the log being updated
long after expected and causing issues with the copy up to the bucket.

Just copy the TSVs and the lims.json, nothing else should really be
required, seems like sometimes are are temporary backups made and that
sort of thing but should not be required.