### PR TITLE
DEV-2460 Do not redirect dsync logs to /tmp

### DIFF
--- a/gcp/sync_data_vm
+++ b/gcp/sync_data_vm
@@ -6,7 +6,7 @@ source locate_gcp_files || exit 1
 
 set -e
 
-info "Syncing ops data from ops-vm used in development"
+info "Syncing data from ops-vm used in development"
 gsutil -mq cp -r gs://data-vm-resources-prod-1/* /data
 info "Done"
 
@@ -23,6 +23,6 @@ java11 -jar ${dsync_jar} \
     --patient_db_url ${db_url} \
     --patient_db_credentials ${credentials} \
     --local_path ${local_path} \
-    --threads 100 > /tmp/dsync-$(date +%Y%m%d%H%M).out
+    --threads 100
 rm ${credentials}
 info "Done"


### PR DESCRIPTION
Without this redirect the logs will end up in the correct directory to
be shipped to GCP so we can see them in the logs viewer (and they will
prompt alerts if appropriate).