### PR TITLE
DEV-2502 Make all repo pulls happen as ops

### DIFF
--- a/crunch/pull_repo
+++ b/crunch/pull_repo
@@ -3,23 +3,9 @@
 source message_functions || exit 1
 source locate_files || exit 1
 
-SCRIPT_NAME="$(basename "$0")"
-
-repo_name=$1 && shift
-
-if [[ -z ${repo_name} ]]; then
-    die "No repo name provided. ${SCRIPT_NAME} requires a repo name as an argument"
-fi
-
-if [[ ${repo_name} != "scripts" ]] && [[ ${repo_name} != "peach" ]]; then
-    die "Only allowed to be used on scripts and peach repos. Other repos are set to a fixed version on purpose."
-fi
-
-repo_path=$(locate_repo_dir "${repo_name}")
-work_path=$(pwd)
-
-if [[ "${USER}" == "root" ]]; then
-    die "This script should not be executed as user root"
+repo_path=$1
+if [[ -z ${repo_path} ]]; then
+    die "No repo path provided. $(basename $0) requires a repo name as an argument"
 fi
 
 if [[ ! -d "${repo_path}" ]]; then
@@ -30,7 +16,5 @@ info "Change dir (to ${repo_path})"
 cd "${repo_path}" || die "Could not switch dir to repo ${repo_path}"
 
 info "Performing pull (in ${repo_path})"
-git pull
+sudo -u ops git pull || die "Pull to ${repo_path} failed"
 
-info "Change dir (to ${work_path})"
-cd "${work_path}" || die "Could not switch dir back to work path ${work_path}"

--- a/crunch/pull_resources_repo
+++ b/crunch/pull_resources_repo
@@ -3,34 +3,11 @@
 source message_functions || exit 1
 source locate_files || exit 1
 
-SCRIPT_NAME="$(basename "$0")"
+repo=$1
+[[ -z ${repo} ]] && die "$(basename $0) requires a repo resources name as an argument"
 
-repo_resources_name=$1 && shift
-
-if [[ -z ${repo_resources_name} ]]; then
-    die "No repo resources name provided. ${SCRIPT_NAME} requires a repo resources name as an argument"
-fi
-
-if [[ ${repo_resources_name} != "ops" ]] && [[ ${repo_resources_name} != "crunch" ]] && [[ ${repo_resources_name} != "private" ]] && [[ ${repo_resources_name} != "public" ]] ; then
+if [ ${repo} != "ops" -a ${repo} != "crunch" -a ${repo} != "private" -a ${repo} != "public" ] ; then
     die "Only allowed to be used on ops ,crunch, private and public resources repos. Other repos are set to a fixed version on purpose."
 fi
 
-repo_resources_path=$(locate_resources_repo_dir "${repo_resources_name}")
-work_path=$(pwd)
-
-if [[ "${USER}" == "root" ]]; then
-    die "This script should not be executed as user root"
-fi
-
-if [[ ! -d "${repo_resources_path}" ]]; then
-    die "Dir does not exist (${repo_resources_path})"
-fi
-
-info "Change dir (to ${repo_resources_path})"
-cd "${repo_resources_path}" || die "Could not switch dir to repo ${repo_resources_path}"
-
-info "Performing pull (in ${repo_resources_path})"
-git pull
-
-info "Change dir (to ${work_path})"
-cd "${work_path}" || die "Could not switch dir back to work path ${work_path}"
+pull_repo $(locate_resources_repo_dir "${repo}")

--- a/crunch/pull_scripts_repo
+++ b/crunch/pull_scripts_repo
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pull_repo "scripts" || exit 1
+pull_source_repo "scripts" || exit 1

--- a/crunch/pull_source_repo
+++ b/crunch/pull_source_repo
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source message_functions || exit 1
+source locate_files || exit 1
+
+repo=$1
+[[ -z ${repo} ]] && die "$(basename $0) requires a repository name as an argument" 
+
+if [ ${repo} != "scripts" -a ${repo} != "peach" ] ; then
+    die "Only allowed to be used on scripts and peach repos. Other repos are set to a fixed version on purpose."
+fi
+
+pull_repo $(locate_repo_dir "${repo}")


### PR DESCRIPTION
Wrapper scripts have been modified to all call through to the same
pull_repo script and another wrapper added for source repositories.

All end users should have no problem elevating to `ops` for the actual
checkout which should resolve some of the permissions problems we're
seeing in the production environment.