### PR TITLE
DEV-2564 Support new verification flow

### DIFF
--- a/hmftools/patientdb/load_run_into_pipeline_verification_db
+++ b/hmftools/patientdb/load_run_into_pipeline_verification_db
@@ -10,8 +10,8 @@ SECRET_NAME="mysql-patients-sql-verification-6-writer"
 set -e
 
 run_dir=$1 && shift
-database=$2 && shift
-patient_db_jar=$3
+database=$1 && shift
+patient_db_jar=$1
 
 if [[ -z "${run_dir}" || -z ${database} ]]; then
     echo "Missing arguments!"

--- a/hmftools/patientdb/load_run_into_pipeline_verification_db
+++ b/hmftools/patientdb/load_run_into_pipeline_verification_db
@@ -5,23 +5,26 @@ source message_functions || exit 1
 source secrets_functions || exit 1
 source metadata_functions || exit 1
 
+SECRET_NAME="mysql-patients-sql-verification-6-writer"
+
 set -e
 
 run_dir=$1 && shift
+database=$2 && shift
+patient_db_jar=$3
 
-if [[ -z "${run_dir}" ]]; then
-    error "No run dir passed. Exiting"
+if [[ -z "${run_dir}" || -z ${database} ]]; then
+    echo "Missing arguments!"
+    error "USAGE: $0 [run directory] [database name] [optional path to patient db JAR]"
 fi
 
-patient_db_jar=$(locate_prod_patient_db)
-secret_name="mysql-verification-db-writer"
-credentials=$(get_secret_from_secret_manager "${secret_name}")
+[[ -z ${patient_db_jar} ]] && patient_db_jar=$(locate_prod_patient_db)
+credentials=$(get_secret_from_secret_manager "${SECRET_NAME}")
 tumor_sample=$(load_tumor_sample_from_metadata "${run_dir}")
-database="hmfpatients"
 
 info "Config (tumor sample): $tumor_sample"
 info "Config (patient db jar): $patient_db_jar"
 info "Config (database): $database"
-info "Config (secret name): ${secret_name}"
+info "Config (secret name): ${SECRET_NAME}"
 
 do_load_run_into_db "${run_dir}" "${patient_db_jar}" "${database}" "${credentials}"

--- a/sql/execution/execute_sql_on_pipeline_verification_db
+++ b/sql/execution/execute_sql_on_pipeline_verification_db
@@ -4,14 +4,14 @@ source message_functions || exit 1
 source database_functions || exit 1
 source secrets_functions || exit 1
 
+database_name=$1 && shift
 sql_file_or_select_statement=$1 && shift
 
-credentials=$(get_secret_from_secret_manager "mysql-diagnostic-patients-sql-pilot-1-writer")
+credentials=$(get_secret_from_secret_manager "mysql-patients-sql-verification-6-writer")
 user=$(extract_database_user "${credentials}")
 password=$(extract_database_password "${credentials}")
-host="diagnostic-genomic.sql.pilot-1"
+host=$(extract_database_host "${credentials}")
 port="3306"
-database_name="hmfpatients"
 from_file='true'
 
 if [[ ! -f "${sql_file_or_select_statement}" ]]; then

--- a/validation/prepare_for_verify_pipeline_run
+++ b/validation/prepare_for_verify_pipeline_run
@@ -56,6 +56,8 @@ main() {
     new_metadata_file="${new_run_url}/metadata.json"
     truth_sample=$(gsutil cat "$truth_metadata_file" | jq -r '.tumor.sampleName')
     new_sample=$(gsutil cat "$new_metadata_file" | jq -r '.tumor.sampleName')
+    truth_version_tag="TODO"
+    new_version_tag="TODO"
 
     info "Creating setup and downloading runs:"
     info "  Out path: ${out_dir}"
@@ -69,8 +71,14 @@ main() {
     download_run_from_gcp "${new_run_url}" "${new_dir_path}" "${out_logs_dir}"
 
     info "Finished with $script"
-    info "Next step: $(printf "nohup verify_pipeline_run -o %s/verification -t %s -n %s > %s/verification.log &" \
-      "${out_dir}" "${truth_dir_path}" "${new_dir_path}" "${out_dir}")"
+    next_cmd="nohup verify_pipeline_run"
+    next_cmd+=" --out_dir ${out_dir}/verification"
+    next_cmd+=" --truth_run_dir ${truth_dir_path}"
+    next_cmd+=" --new_run_dir ${new_dir_path}"
+    next_cmd+=" --truth_version_tag ${truth_version_tag}"
+    next_cmd+=" --new_version_tag ${new_version_tag}"
+    next_cmd+=" > ${out_dir}/verification.log &"
+    info "Next step: $next_cmd"
 }
 
 check_pipeline_version_file () {

--- a/validation/run_all_sql_verification_jobs
+++ b/validation/run_all_sql_verification_jobs
@@ -5,11 +5,12 @@ source message_functions || exit 1
 jobs_dir=$1
 logs_dir=$2
 tag=$3 # eg "before_load"
+db_schema=$4
 
 find "${jobs_dir}" -type f -name "*.sql" | while read -r sql_file ; do
     job_name="$(basename "${sql_file}")"
     log_file="${logs_dir}/${tag}_${job_name}.log"
     info "Executing ${job_name} (log: ${log_file})"
-    execute_sql_on_pipeline_verification_db "${sql_file}" > "${log_file}"
+    execute_sql_on_pipeline_verification_db "${db_schema}" "${sql_file}" > "${log_file}"
 done
 

--- a/validation/verify_pipeline_run
+++ b/validation/verify_pipeline_run
@@ -20,17 +20,18 @@ cat <<EOM
  Optional arguments:
    --disable_sanity_checks    Disable extra checks
    --patientdb_jar [jar]      Use [jar] instead of default [${patientdb_jar}]
------"
+-----
 EOM
     exit 1
 }
 
-args=$(getopt --long disable_sanity_checks,out_dir:,truth_run_dir:,truth_run_version:,new_run_dir:,new_run_version:,patientdb_jar: -- "$@")
+sanity_checks="TRUE"
+args=$(getopt -o "" --longoptions disable_sanity_checks,out_dir:,truth_run_dir:,truth_run_version:,new_run_dir:,new_run_version:,patientdb_jar: -- "$@")
+[[ $? != 0 ]] && echo "Bad arguments" && exit 1
 eval set -- "$args"
 
-sanity_checks="TRUE"
 while true; do
-    case "${1}" in
+    case "$1" in
         --out_dir) out_dir=${2} ; shift 2 ;;
         --truth_run_dir) truth_run_dir=${2} ; shift 2 ;;
         --truth_run_version) truth_run_version=${2} ; shift 2 ;;
@@ -39,11 +40,11 @@ while true; do
         --disable_sanity_checks) sanity_checks="FALSE"; shift ;;
         --patientdb_jar) patientdb_jar=${2} ; shift 2 ;;
         -- ) shift; break ;;
-        *) print_usage ;;
     esac
 done
 
 if [[ -z "${out_dir}" || -z "${truth_run_dir}" || -z "${new_run_dir}" || -z "${truth_run_version}" || -z "${new_run_version}" ]]; then
+    echo "Missing arguments!"
     print_usage
 fi
 

--- a/validation/verify_pipeline_run
+++ b/validation/verify_pipeline_run
@@ -1,50 +1,62 @@
 #!/usr/bin/env bash
 
 source message_functions || exit 1
+source locate_files || exit 1
 
 script="$(basename "$0")"
+patientdb_jar="$(locate_prod_patient_db)"
 
-print_usage(){
-    echo "-----"
-    echo " Descr: Verifies a new COLO829T Somatic pipeline run"
-    echo " Usage: $script -o <out_dir> -t <truth_dir> -n <truth_dir>"
-    echo " Options:"
-    echo "   -o  out_dir    Path to output directory"
-    echo "   -t  truth_run  Path to directory of truth run"
-    echo "   -n  new_run    Path to directory of new run to be verified"
-    echo "   -f  force      Continue if output directory already exists"
-    echo " Example:"
-    echo "   $script -o /path/to/outdir -t /path/to/COLO829v003T_524 -n /path/to/COLO829v003T_525"
-    echo "-----"
+print_usage() {
+cat <<EOM
+-----
+ Descr: Verifies a new COLO829T Somatic pipeline run
+ Usage: $script [required arguments] [optional arguments]
+ Required arguments:
+   --out_dir [dir]            Output to directory [dir]
+   --truth_run_dir [dir]      Use [dir] as location containing truth run
+   --truth_run_version [ver]  Short version of truth run (eg "527")
+   --new_run_dir [dir]        Use [dir] as location containing run to be verified         
+   --new_run_version          Short version of run being verified (eg "528")
+ Optional arguments:
+   --disable_sanity_checks    Disable extra checks
+   --patientdb_jar [jar]      Use [jar] instead of default [${patientdb_jar}]
+-----"
+EOM
     exit 1
 }
 
+args=$(getopt --long disable_sanity_checks,out_dir:,truth_run_dir:,truth_run_version:,new_run_dir:,new_run_version:,patientdb_jar: -- "$@")
+eval set -- "$args"
+
 sanity_checks="TRUE"
-while getopts ':fo:t:n:' flag; do
-    case "${flag}" in
-        f) sanity_checks="FALSE" ;;
-        o) out_dir=${OPTARG} ;;
-        t) truth_run=${OPTARG} ;;
-        n) new_run=${OPTARG} ;;
-        *) print_usage
-        exit 1 ;;
+while true; do
+    case "${1}" in
+        --out_dir) out_dir=${2} ; shift 2 ;;
+        --truth_run_dir) truth_run_dir=${2} ; shift 2 ;;
+        --truth_run_version) truth_run_version=${2} ; shift 2 ;;
+        --new_run_dir) new_run_dir=${2} ; shift 2 ;;
+        --new_run_version) new_run_version=${2} ; shift 2 ;;
+        --disable_sanity_checks) sanity_checks="FALSE"; shift ;;
+        --patientdb_jar) patientdb_jar=${2} ; shift 2 ;;
+        -- ) shift; break ;;
+        *) print_usage ;;
     esac
 done
 
-if [[ -z "${out_dir}" || -z "${truth_run}" || -z "${new_run}" ]]; then
+if [[ -z "${out_dir}" || -z "${truth_run_dir}" || -z "${new_run_dir}" || -z "${truth_run_version}" || -z "${new_run_version}" ]]; then
     print_usage
 fi
 
 main() {
     info "Starting with script $script"
 
-    truth_run=$(realpath "$truth_run")
-    new_run=$(realpath "$new_run")
+    truth_run=$(realpath "$truth_run_dir")
+    new_run=$(realpath "$new_run_dir")
     
     ## some input sanity checks
     [[ -n "${out_dir}" && "${out_dir}" =~ ^\/ ]] || die "Incorrect out_dir format (${out_dir})?"
-    [[ -f "${new_run}/pipeline.version" ]] || die "Pipeline version file missing (in new run: ${new_run})"
     [[ -d "${new_run}" ]] || die "New run dir not found (${new_run})"
+    [[ -f "${new_run}/pipeline.version" ]] || die "Pipeline version file missing (in new run: ${new_run})"
     [[ -d "${truth_run}" ]] || die "Truth run dir not found (${truth_run})"
     if [[ "${sanity_checks}" == "TRUE" ]]; then
         [[ ! -d "${out_dir}" ]] || die "Output dir exists (${out_dir})"
@@ -100,8 +112,8 @@ main() {
 
     # Somewhat hacky way of replacing the variables of template SQL
     info "Replacing variables in SQL job files"
-    truth_db_schema="hmfpatients"
-    new_db_schema="hmfpatients"
+    truth_db_schema="hmfpatients_${truth_run_version}"
+    new_db_schema="hmfpatients_${new_run_version}"
     for sql_file_name in "${sql_jobs[@]}"; do
         sed -i "s/VARIABLE_TRUTH_SAMPLE_ID/${truth_sample}/g" "${jobs_dir}/${sql_file_name}"
         sed -i "s/VARIABLE_NEW_SAMPLE_ID/${new_sample}/g" "${jobs_dir}/${sql_file_name}"
@@ -126,18 +138,19 @@ main() {
     sql_query_script="${jobs_dir}/run_all_sql_verification_jobs"
 
     #before_db_load_job="${jobs_dir}/run_sql_jobs_before_db_load"
-    #echo "${sql_query_script} ${jobs_dir} ${logs_dir} before_load" > "${before_db_load_job}"
+    #echo "${sql_query_script} ${jobs_dir} ${logs_dir} before_load ${new_db_schema}" > "${before_db_load_job}"
     #chmod +x "${before_db_load_job}"
 
     after_db_load_job="${jobs_dir}/run_sql_jobs_after_db_load"
-    echo "${sql_query_script} ${jobs_dir} ${logs_dir} after_load" > "${after_db_load_job}"
+    echo "${sql_query_script} ${jobs_dir} ${logs_dir} after_load ${new_db_schema}" > "${after_db_load_job}"
     chmod +x "${after_db_load_job}"
 
     info "TODO:"
     info "  1. Inspect all log files in ${logs_dir}"
-    info "  2. Load into DB (nohup ${db_load_script} ${new_run} > ${logs_dir}/${db_load_script}.log &)"
-    info "  3. Execute sql queries (nohup ${after_db_load_job} > ${logs_dir}/sql_verification_after_load.log &)"
-    info "  4. Inspect all SQL log files in logs dir (ls ${logs_dir})"
+    info "  2. Ensure database \"${new_db_schema}\" exists in verification instance on GCP"
+    info "  3. Load into DB (nohup ${db_load_script} ${new_run} ${new_db_schema} ${patientdb_jar} > ${logs_dir}/${db_load_script}.log &)"
+    info "  4. Execute sql queries (nohup ${after_db_load_job} > ${logs_dir}/sql_verification_after_load.log &)"
+    info "  5. Inspect all SQL log files in logs dir (ls ${logs_dir})"
     info "Finished with $script"
 }
 


### PR DESCRIPTION
With this approach we will have a new DB schema every time we do a
verification, so we will no longer have to rename samples for every
run.

The changes here add the arguments we'll need to allow the use of two
schemas, as the previous flow assumed a single database with different
sample names for each run.

There is probably more to do here, I haven't tested everything yet.