### PR TITLE
DEV-3669 Make Autoclass buckets from make_bucket

### DIFF
--- a/gcp/make_bucket
+++ b/gcp/make_bucket
@@ -11,7 +11,7 @@ print_usage() {
     exit 1
 }
 
-while getopts ':n:p:c:a' flag; do
+while getopts ':n:p:c:b' flag; do
     case "${flag}" in
         b) backup_only=true ;;
         c) cost_center=${OPTARG} ;;

--- a/gcp/make_bucket
+++ b/gcp/make_bucket
@@ -3,18 +3,20 @@
 source message_functions || exit 1
 
 print_usage() {
-    echo "Usage: $(basename $0) -n bucket_name -p project_name"
+    echo "Usage: $(basename $0) [arguments]"
+    echo "  -b                  Bucket is for backup (archival) only and is not expected to be read from in normal circumstances"
+    echo "  -c cost_center      Assign a cost center to this bucket"
     echo "  -n bucket_name      Name of the bucket to be created"
     echo "  -p project_name     Name of the project in which to create bucket"
-    echo "  -c cost_center      Assign a cost center to this bucket"
     exit 1
 }
 
-while getopts ':n:p:c:' flag; do
+while getopts ':n:p:c:a' flag; do
     case "${flag}" in
+        b) backup_only=true ;;
+        c) cost_center=${OPTARG} ;;
         n) bucket_name=${OPTARG} ;;
         p) project_name=${OPTARG} ;;
-        c) cost_center=${OPTARG} ;;
         *) print_usage
         exit 1 ;;
     esac
@@ -24,8 +26,13 @@ if [[ -z "${bucket_name}" || -z "${project_name}" || -z "${cost_center}" ]]; the
     print_usage
 fi
 
+class_args="--autoclass"
+if [[ -n $backup_only ]]; then
+  class_args="-c archive"
+fi
+
 info "Creating bucket in GCP. Disregard warnings about KMS permissions, our storage accounts are authorized."
-gsutil mb -c standard -b on -l europe-west4 -p ${project_name} gs://${bucket_name}
+gsutil mb ${class_args} -b on -l europe-west4 -p ${project_name} gs://${bucket_name}
 gsutil kms encryption -w -k projects/hmf-database/locations/europe-west4/keyRings/hmf-database/cryptoKeys/hmf-database-20191001 gs://${bucket_name}
 gsutil label ch -l user:$USER gs://${bucket_name}
 gsutil label ch -l cost_center:${cost_center} gs://${bucket_name}


### PR DESCRIPTION
The default now is to make Autoclass-enabled buckets rather than "standard" class buckets. The user can override this by specifically indicating `-b` to have their bucket created statically with the archive class.