### PR TITLE
ACTIN-192 Add an operational script to run treatment match loader

### DIFF
--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -25,6 +25,7 @@ if [ -z "$database_exists" ]; then
   echo "Database '$db_name' does not exist. Loading SQL script..."
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "CREATE DATABASE $db_name;"
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
+  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_actin_database_views_sql
 
 else
   echo "Database '$DATABASE_NAME' already exists."

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+source message_functions || exit 1
+source database_functions || exit 1
+source locate_files || exit 1
+
+patient=$1 && shift
+
+if [[ -z "${patient}" ]]; then
+    error "This script takes a patient as an argument"
+fi
+
+actin_database_sql="$(locate_actin_database_sql_script)"
+
+db_host="actin-sql.prod"
+db_port=3306
+db_user="writer"
+db_pass=$(gcloud secrets versions access latest --secret="prod-sql-writer-password")
+db_name=actin_operations
+
+database_exists=$(mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "SHOW DATABASES LIKE '${db_name}';" | grep "$db_name")
+
+if [ -z "$database_exists" ]; then
+  echo "Database '$db_name' does not exist. Loading SQL script..."
+  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
+
+else
+  echo "Database '$DATABASE_NAME' already exists."
+fi
+
+treatment_match_json="$(locate_actin_treatment_match_json ${patient})"
+
+java -cp /data/system/actin.jar com.hartwig.actin.database.algo.TreatmentMatchLoaderApplication \
+    -treatment_match_json ${treatment_match_json} \
+    -db_user ${db_user} -db_pass ${db_pass} -db_url "mysql://${db_host}:${db_port}/${db_name}"

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -13,16 +13,16 @@ fi
 actin_jar="$(locate_pilot_actin)"
 
 db_host="actin-sql.prod"
-db_port=3306
+db_port="3306"
 db_user="writer"
 db_pass=$(gcloud secrets versions access latest --secret="prod-sql-writer-password")
-db_name=actin_operations
+db_name="actin_operations"
 
 database_exists=$(mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "SHOW DATABASES LIKE '${db_name}';" | grep "${db_name}")
 
 if [ -z "$database_exists" ]; then
     echo "Database '${db_name}' does not exist. Loading SQL script..."
-    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "CREATE DATABASE $db_name;"
+    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "CREATE DATABASE ${db_name};"
     mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p ${actin_jar} generate_database.sql
     mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p ${actin_jar} generate_views.sql
 else

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -23,8 +23,8 @@ database_exists=$(mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "SHOW 
 if [ -z "$database_exists" ]; then
     echo "Database '${db_name}' does not exist. Loading SQL script..."
     mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "CREATE DATABASE ${db_name};"
-    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p "${actin_jar}" generate_database.sql
-    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p "${actin_jar}" generate_views.sql
+    unzip -p "${actin_jar}" generate_database.sql | mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}"
+    unzip -p "${actin_jar}" generate_views.sql | mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}"
 else
     echo "Database '${db_name}' already exists."
 fi

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -25,7 +25,7 @@ if [ -z "$database_exists" ]; then
   echo "Database '$db_name' does not exist. Loading SQL script..."
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "CREATE DATABASE $db_name;"
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
-  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_actin_database_views_sql
+  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_views_sql
 
 else
   echo "Database '$DATABASE_NAME' already exists."

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -22,6 +22,7 @@ database_exists=$(mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "SHOW DATABA
 
 if [ -z "$database_exists" ]; then
   echo "Database '$db_name' does not exist. Loading SQL script..."
+  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < "CREATE DATABASE $db_name;"
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
 
 else

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -22,7 +22,7 @@ database_exists=$(mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "SHOW DATABA
 
 if [ -z "$database_exists" ]; then
   echo "Database '$db_name' does not exist. Loading SQL script..."
-  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" -e "CREATE DATABASE $db_name;"
+  mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "CREATE DATABASE $db_name;"
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
 
 else

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -31,6 +31,6 @@ fi
 
 treatment_match_json="$(locate_actin_treatment_match_json ${patient})"
 
-java -cp /data/system/actin.jar com.hartwig.actin.database.algo.TreatmentMatchLoaderApplication \
+java -cp /data/actin/system/actin.jar com.hartwig.actin.database.algo.TreatmentMatchLoaderApplication \
     -treatment_match_json ${treatment_match_json} \
     -db_user ${db_user} -db_pass ${db_pass} -db_url "mysql://${db_host}:${db_port}/${db_name}"

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -10,8 +10,7 @@ if [[ -z "${patient}" ]]; then
     error "This script takes a patient as an argument"
 fi
 
-actin_database_sql="$(locate_actin_database_sql_script)"
-actin_database_views_sql="$(locate_actin_database_views_sql_script)"
+actin_jar="$(locate_pilot_actin)"
 
 db_host="actin-sql.prod"
 db_port=3306
@@ -19,20 +18,19 @@ db_user="writer"
 db_pass=$(gcloud secrets versions access latest --secret="prod-sql-writer-password")
 db_name=actin_operations
 
-database_exists=$(mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "SHOW DATABASES LIKE '${db_name}';" | grep "$db_name")
+database_exists=$(mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "SHOW DATABASES LIKE '${db_name}';" | grep "${db_name}")
 
 if [ -z "$database_exists" ]; then
-  echo "Database '$db_name' does not exist. Loading SQL script..."
-  mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "CREATE DATABASE $db_name;"
-  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
-  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_views_sql
-
+    echo "Database '${db_name}' does not exist. Loading SQL script..."
+    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "CREATE DATABASE $db_name;"
+    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p ${actin_jar} generate_database.sql
+    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p ${actin_jar} generate_views.sql
 else
-  echo "Database '$DATABASE_NAME' already exists."
+    echo "Database '${db_name}' already exists."
 fi
 
 treatment_match_json="$(locate_actin_treatment_match_json ${patient})"
 
-java -cp /data/actin/system/actin.jar com.hartwig.actin.database.algo.TreatmentMatchLoaderApplication \
+java -cp ${actin_jar}  com.hartwig.actin.database.algo.TreatmentMatchLoaderApplication \
     -treatment_match_json ${treatment_match_json} \
     -db_user ${db_user} -db_pass ${db_pass} -db_url "mysql://${db_host}:${db_port}/${db_name}"

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -23,8 +23,8 @@ database_exists=$(mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "SHOW 
 if [ -z "$database_exists" ]; then
     echo "Database '${db_name}' does not exist. Loading SQL script..."
     mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" -e "CREATE DATABASE ${db_name};"
-    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p ${actin_jar} generate_database.sql
-    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p ${actin_jar} generate_views.sql
+    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p "${actin_jar}" generate_database.sql
+    mysql -u "${db_user}" -p"${db_pass}" -h "${db_host}" "${db_name}" < unzip -p "${actin_jar}" generate_views.sql
 else
     echo "Database '${db_name}' already exists."
 fi

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -11,6 +11,7 @@ if [[ -z "${patient}" ]]; then
 fi
 
 actin_database_sql="$(locate_actin_database_sql_script)"
+actin_database_views_sql="$(locate_actin_database_views_sql_script)"
 
 db_host="actin-sql.prod"
 db_port=3306

--- a/actin/operational/load_actin_operational_data
+++ b/actin/operational/load_actin_operational_data
@@ -22,7 +22,7 @@ database_exists=$(mysql -u "$db_user" -p"$db_pass" -h "$db_host" -e "SHOW DATABA
 
 if [ -z "$database_exists" ]; then
   echo "Database '$db_name' does not exist. Loading SQL script..."
-  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < "CREATE DATABASE $db_name;"
+  mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" -e "CREATE DATABASE $db_name;"
   mysql -u "$db_user" -p"$db_pass" -h "$db_host" "$db_name" < $actin_database_sql
 
 else

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -326,6 +326,10 @@ locate_actin_database_sql_script() {
     echo "/data/resources/crunch/actin/sql_database/generate_database.sql"
 }
 
+locate_actin_database_views_sql_script() {
+    echo "/data/resources/crunch/actin/sql_database/generate_views.sql"
+}
+
 locate_actin_clinical_curation_directory() {
     echo "/data/resources/crunch/actin/clinical_curation"
 }


### PR DESCRIPTION
In the interest of simplification, we'll only support the treatment match loader to start (which populates all tables required
for `trialEvaluation` view.  

The current factoring of the loader scripts makes reusing the current loader scripts awkward without refactoring, 
so there is a little duplication here. Could invest more time to remove it, but doesn't seem worthwhile to me as 
this will eventually all be automated outside the VM. 