### PR TITLE
ACTIN-431 Copy bucket located pipeline outputs to archival buckets

### DIFF
--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -36,8 +36,8 @@ if [[ -z "${clinical_json}" || -z "${treatment_match_json}" || -z "${actin_repor
 fi
 
 molecular_dir="$(locate_actin_molecular_directory_for_sample ${sample})"
-orange_json="$(locate_orange_json ${molecular_dir})"
-orange_pdf="$(locate_orange_pdf ${molecular_dir})"
+orange_json="$(locate_actin_orange_no_germline_json ${molecular_dir})"
+orange_pdf="$(locate_actin_orange_no_germline__pdf ${molecular_dir})"
 molecular_json="$(locate_actin_molecular_json ${sample})"
 
 if [[ -f "${orange_json}" && -f "${orange_pdf}" && -f "${molecular_json}" ]]; then

--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -37,7 +37,7 @@ fi
 
 molecular_dir="$(locate_actin_molecular_directory_for_sample ${sample})"
 orange_json="$(locate_actin_orange_no_germline_json ${molecular_dir})"
-orange_pdf="$(locate_actin_orange_no_germline__pdf ${molecular_dir})"
+orange_pdf="$(locate_actin_orange_no_germline_pdf ${molecular_dir})"
 molecular_json="$(locate_actin_molecular_json ${sample})"
 
 if [[ -f "${orange_json}" && -f "${orange_pdf}" && -f "${molecular_json}" ]]; then

--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -25,19 +25,19 @@ if [[ "${bucket_exists_error}" != *"CommandException"* ]]; then
     fi
 fi
 
-clinical_json="$(locate_actin_clinical_json ${patient})"
-treatment_match_json="$(locate_actin_treatment_match_json ${patient})"
-actin_report_pdf="$(locate_actin_report_pdf ${patient})"
-evaluation_details_tsv="$(locate_actin_evaluation_details ${patient})"
-evaluation_summary_tsv="$(locate_actin_evaluation_summary ${patient})"
+clinical_json="$(locate_actin_clinical_json_gcp ${patient})"
+treatment_match_json="$(locate_actin_treatment_match_json_gcp ${patient})"
+actin_report_pdf="$(locate_actin_report_pdf_gcp ${patient})"
+evaluation_details_tsv="$(locate_actin_evaluation_details_gcp ${patient})"
+evaluation_summary_tsv="$(locate_actin_evaluation_summary_gcp ${patient})"
 
 if [[ -z "${clinical_json}" || -z "${treatment_match_json}" || -z "${actin_report_pdf}" || -z "${evaluation_details_tsv}" || -z "${evaluation_summary_tsv}" ]]; then
     error "Missing ACTIN data, report or evaluation details for ${sample}"
 fi
 
-orange_json="$(locate_actin_orange_no_germline_json ${sample})"
-orange_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
-molecular_json="$(locate_actin_molecular_json ${sample})"
+orange_json="$(locate_actin_orange_no_germline_json_gcp ${sample})"
+orange_pdf="$(locate_actin_orange_no_germline_pdf_gcp ${sample})"
+molecular_json="$(locate_actin_molecular_json_gcp ${sample})"
 
 if [[ -z "${orange_json}" && -z "${orange_pdf}" && -z "${molecular_json}" ]]; then
     warn "Skipping archiving of ORANGE data and ACTIN molecular interpretation for ${sample} as they do not exist"

--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -39,6 +39,10 @@ orange_json="$(locate_actin_orange_no_germline_json ${sample})"
 orange_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
 molecular_json="$(locate_actin_molecular_json ${sample})"
 
+echo "ORANGE json ${orange_json}"
+echo "ORANGE pdf ${orange_json}"
+echo "molecular json ${orange_json}"
+
 if [[ -f "${orange_json}" && -f "${orange_pdf}" && -f "${molecular_json}" ]]; then
     info "Archiving ORANGE data, report and ACTIN interpretation for ${sample}"
     gsutil cp "${orange_json}" "${sample_evaluation_bucket}/"

--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -40,7 +40,7 @@ orange_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
 molecular_json="$(locate_actin_molecular_json ${sample})"
 
 echo "ORANGE json ${orange_json}"
-echo "ORANGE pdf ${orange_json}"
+echo "ORANGE pdf ${orange_pdf}"
 echo "molecular json ${orange_json}"
 
 if [[ -f "${orange_json}" && -f "${orange_pdf}" && -f "${molecular_json}" ]]; then

--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -39,17 +39,13 @@ orange_json="$(locate_actin_orange_no_germline_json ${sample})"
 orange_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
 molecular_json="$(locate_actin_molecular_json ${sample})"
 
-echo "ORANGE json ${orange_json}"
-echo "ORANGE pdf ${orange_pdf}"
-echo "molecular json ${orange_json}"
-
-if [[ -f "${orange_json}" && -f "${orange_pdf}" && -f "${molecular_json}" ]]; then
+if [[ -z "${orange_json}" && -z "${orange_pdf}" && -z "${molecular_json}" ]]; then
+    warn "Skipping archiving of ORANGE data and ACTIN molecular interpretation for ${sample} as they do not exist"
+else
     info "Archiving ORANGE data, report and ACTIN interpretation for ${sample}"
     gsutil cp "${orange_json}" "${sample_evaluation_bucket}/"
     gsutil cp "${orange_pdf}" "${sample_evaluation_bucket}/"
     gsutil cp "${molecular_json}" "${sample_evaluation_bucket}/"
-else
-    warn "Skipping archiving of ORANGE data and ACTIN molecular interpretation for ${sample} as they do not exist"
 fi
 
 info "Archiving ACTIN data and report for ${patient}"

--- a/actin/operational/archive_actin_all_output_for_evaluation
+++ b/actin/operational/archive_actin_all_output_for_evaluation
@@ -35,9 +35,8 @@ if [[ -z "${clinical_json}" || -z "${treatment_match_json}" || -z "${actin_repor
     error "Missing ACTIN data, report or evaluation details for ${sample}"
 fi
 
-molecular_dir="$(locate_actin_molecular_directory_for_sample ${sample})"
-orange_json="$(locate_actin_orange_no_germline_json ${molecular_dir})"
-orange_pdf="$(locate_actin_orange_no_germline_pdf ${molecular_dir})"
+orange_json="$(locate_actin_orange_no_germline_json ${sample})"
+orange_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
 molecular_json="$(locate_actin_molecular_json ${sample})"
 
 if [[ -f "${orange_json}" && -f "${orange_pdf}" && -f "${molecular_json}" ]]; then

--- a/actin/operational/archive_actin_orange_report_after_sharing
+++ b/actin/operational/archive_actin_orange_report_after_sharing
@@ -10,7 +10,7 @@ if [[ -z "${sample}" ]]; then
 fi
 
 shared_reports_bucket="$(locate_actin_shared_reports_bucket)"
-orange_no_germline_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
+orange_no_germline_pdf="$(locate_actin_orange_no_germline_pdf_gcp ${sample})"
 
 info "Archiving ORANGE (no germline) report for ${sample}"
 gsutil cp "${orange_no_germline_pdf}" "${shared_reports_bucket}/orange/"

--- a/actin/operational/archive_actin_orange_report_after_sharing
+++ b/actin/operational/archive_actin_orange_report_after_sharing
@@ -10,13 +10,7 @@ if [[ -z "${sample}" ]]; then
 fi
 
 shared_reports_bucket="$(locate_actin_shared_reports_bucket)"
-
-molecular_dir="$(locate_actin_molecular_directory_for_sample ${sample})"
-orange_no_germline_pdf="$(locate_orange_no_germline_pdf ${molecular_dir})"
-
-if [[ -z "${orange_no_germline_pdf}" ]]; then
-    error "Missing ORANGE report for ${sample}"
-fi
+orange_no_germline_pdf="$(locate_actin_orange_no_germline_pdf ${molecular_dir})"
 
 info "Archiving ORANGE (no germline) report for ${sample}"
 gsutil cp "${orange_no_germline_pdf}" "${shared_reports_bucket}/orange/"

--- a/actin/operational/archive_actin_orange_report_after_sharing
+++ b/actin/operational/archive_actin_orange_report_after_sharing
@@ -10,7 +10,7 @@ if [[ -z "${sample}" ]]; then
 fi
 
 shared_reports_bucket="$(locate_actin_shared_reports_bucket)"
-orange_no_germline_pdf="$(locate_actin_orange_no_germline_pdf ${molecular_dir})"
+orange_no_germline_pdf="$(locate_actin_orange_no_germline_pdf ${sample})"
 
 info "Archiving ORANGE (no germline) report for ${sample}"
 gsutil cp "${orange_no_germline_pdf}" "${shared_reports_bucket}/orange/"

--- a/actin/operational/archive_actin_report_after_sharing
+++ b/actin/operational/archive_actin_report_after_sharing
@@ -11,7 +11,7 @@ fi
 
 shared_reports_bucket="$(locate_actin_shared_reports_bucket)"
 
-actin_report_pdf="$(locate_actin_report_pdf ${patient})"
+actin_report_pdf="$(locate_actin_report_pdf_gcp ${patient})"
 
 info "Archiving ACTIN report for ${patient}"
 gsutil cp "${actin_report_pdf}" "${shared_reports_bucket}/actin/"

--- a/actin/operational/archive_actin_report_after_sharing
+++ b/actin/operational/archive_actin_report_after_sharing
@@ -13,9 +13,5 @@ shared_reports_bucket="$(locate_actin_shared_reports_bucket)"
 
 actin_report_pdf="$(locate_actin_report_pdf ${patient})"
 
-if [[ -z "${actin_report_pdf}" ]]; then
-    error "Missing ACTIN report for ${patient}"
-fi
-
 info "Archiving ACTIN report for ${patient}"
 gsutil cp "${actin_report_pdf}" "${shared_reports_bucket}/actin/"

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -448,7 +448,7 @@ locate_actin_blob(){
 
 locate_actin_clinical_json() {
   local patient=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_clinical_output_bucket}/${patient}.clinical.json"
+  local reportGsutilUri="gs://$(locate_actin_clinical_output_bucket)/${patient}.clinical.json"
   echo $(locate_actin_blob reportGsutilUri "clinical json")
 }
 
@@ -460,43 +460,43 @@ locate_actin_clinical_json_for_sample() {
 
 locate_actin_molecular_json() {
   local sample=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/molecular/${sample}.molecular.json"
+  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)}/molecular/${sample}.molecular.json"
   echo $(locate_actin_blob reportGsutilUri "molecular json")
 }
 
 locate_actin_orange_json() {
   local sample=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/orange/${sample}.orange.json"
+  local reportGsutilUri = "gs://$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
   echo $(locate_actin_blob reportGsutilUri "orange json")
 }
 
 locate_actin_orange_pdf() {
   local sample=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/orange/${sample}.orange.pdf"
+  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
   echo $(locate_actin_blob reportGsutilUri "orange pdf")
 }
 
 locate_actin_treatment_match_json() {
   local patient=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_clinical_output_bucket}/algo/${patient}.treatment_match.json"
+  local reportGsutilUri="gs://$(locate_actin_clinical_output_bucket)/algo/${patient}.treatment_match.json"
   echo $(locate_actin_blob reportGsutilUri "treatment match json")
 }
 
 locate_actin_report_pdf() {
   local patient=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/report/${patient}.actin.pdf"
+  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/report/${patient}.actin.pdf"
   echo $(locate_actin_blob reportGsutilUri "ACTIN report PDF")
 }
 
 locate_actin_evaluation_details() {
   local patient=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/evaluation/${patient}.evaluation.details.tsv"
+  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.details.tsv"
   echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation details")
 }
 
 locate_actin_evaluation_summary() {
   local patient=$1 && shift
-  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/evaluation/${patient}.evaluation.summary.tsv"
+  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.summary.tsv"
   echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation summary")
 }
 

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -448,7 +448,7 @@ locate_actin_blob(){
 
 locate_actin_clinical_json() {
   local patient=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_clinical_output_bucket)/${patient}.clinical.json"
+  local reportGsutilUri="$(locate_actin_clinical_output_bucket)/${patient}.clinical.json"
   echo $(locate_actin_blob reportGsutilUri "clinical json")
 }
 
@@ -460,43 +460,43 @@ locate_actin_clinical_json_for_sample() {
 
 locate_actin_molecular_json() {
   local sample=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)}/molecular/${sample}.molecular.json"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)}/molecular/${sample}.molecular.json"
   echo $(locate_actin_blob reportGsutilUri "molecular json")
 }
 
 locate_actin_orange_json() {
   local sample=$1 && shift
-  local reportGsutilUri = "gs://$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
+  local reportGsutilUri = "$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
   echo $(locate_actin_blob reportGsutilUri "orange json")
 }
 
 locate_actin_orange_pdf() {
   local sample=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
   echo $(locate_actin_blob reportGsutilUri "orange pdf")
 }
 
 locate_actin_treatment_match_json() {
   local patient=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_clinical_output_bucket)/algo/${patient}.treatment_match.json"
+  local reportGsutilUri="$(locate_actin_clinical_output_bucket)/algo/${patient}.treatment_match.json"
   echo $(locate_actin_blob reportGsutilUri "treatment match json")
 }
 
 locate_actin_report_pdf() {
   local patient=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/report/${patient}.actin.pdf"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/report/${patient}.actin.pdf"
   echo $(locate_actin_blob reportGsutilUri "ACTIN report PDF")
 }
 
 locate_actin_evaluation_details() {
   local patient=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.details.tsv"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.details.tsv"
   echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation details")
 }
 
 locate_actin_evaluation_summary() {
   local patient=$1 && shift
-  local reportGsutilUri="gs://$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.summary.tsv"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.summary.tsv"
   echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation summary")
 }
 

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -464,13 +464,13 @@ locate_actin_molecular_json() {
   echo $(locate_actin_blob reportGsutilUri "molecular json")
 }
 
-locate_actin_orange_json() {
+locate_actin_orange_no_germline__json() {
   local sample=$1 && shift
   local reportGsutilUri = "$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
   echo $(locate_actin_blob reportGsutilUri "orange json")
 }
 
-locate_actin_orange_pdf() {
+locate_actin_orange_no_germline_pdf() {
   local sample=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
   echo $(locate_actin_blob reportGsutilUri "orange pdf")
@@ -478,7 +478,7 @@ locate_actin_orange_pdf() {
 
 locate_actin_treatment_match_json() {
   local patient=$1 && shift
-  local reportGsutilUri="$(locate_actin_clinical_output_bucket)/algo/${patient}.treatment_match.json"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/algo/${patient}.treatment_match.json"
   echo $(locate_actin_blob reportGsutilUri "treatment match json")
 }
 

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -460,7 +460,7 @@ locate_actin_clinical_json_for_sample() {
 
 locate_actin_molecular_json() {
   local sample=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)}/molecular/${sample}.molecular.json"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/molecular/${sample}.molecular.json"
   echo $(locate_actin_blob ${reportGsutilUri} "molecular json")
 }
 

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -442,7 +442,7 @@ locate_actin_blob(){
   if gsutil ls "${reportGsutilUri}" >/dev/null 2>&1; then
     echo "${reportGsutilUri}"
   else
-    error "Could not locate ${name} for patient '${patient}'"
+    error "Could not locate ${name} at ${gsutilUri}"
   fi
 }
 

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -431,7 +431,7 @@ locate_actin_prod_data_bucket() {
 }
 
 locate_actin_analysis_bucket() {
-  echo "gs://actin-prod-analysis-output"
+  echo "gs://actin-prod-actin-analysis-output"
 }
 
 ################################# ACTIN Data Bucket Based ###################################

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -455,7 +455,7 @@ locate_actin_clinical_json() {
 locate_actin_clinical_json_for_sample() {
   local sample=$1 && shift
   patient=$(echo ${sample} | head -c 12)
-  locate_actin_clinical_json patient
+  echo $(locate_actin_clinical_json ${patient})
 }
 
 locate_actin_molecular_json() {

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -410,6 +410,10 @@ locate_actin_clinical_data_feed_bucket() {
     echo "gs://actin-prod-clinical-data-feed"
 }
 
+locate_actin_clinical_output_bucket() {
+    echo "gs://actin-prod-clinical-pipeline-output"
+}
+
 locate_actin_evaluation_bucket() {
     echo "gs://actin-prod-evaluation"
 }
@@ -426,47 +430,84 @@ locate_actin_prod_data_bucket() {
     echo "gs://actin-prod-patient-data"
 }
 
-################################# ACTIN Data ###################################
-
-locate_actin_clinical_input_feed_directory() {
-    echo "/data/actin/clinical/input_feed/latest"
+locate_actin_analysis_bucket() {
+  echo "gs://actin-prod-analysis-output"
 }
+
+################################# ACTIN Data Bucket Based ###################################
+
+locate_actin_blob(){
+  local gsutilUri=$1 && shift
+  local name=$1 && shift
+  if gsutil ls "${reportGsutilUri}" >/dev/null 2>&1; then
+    echo "${reportGsutilUri}"
+  else
+    error "Could not locate ${name} for patient '${patient}'"
+  fi
+}
+
+locate_actin_clinical_json() {
+  local patient=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_clinical_output_bucket}/${patient}.clinical.json"
+  echo $(locate_actin_blob reportGsutilUri "clinical json")
+}
+
+locate_actin_clinical_json_for_sample() {
+  local sample=$1 && shift
+  patient=$(echo ${sample} | head -c 12)
+  locate_actin_clinical_json patient
+}
+
+locate_actin_molecular_json() {
+  local sample=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/molecular/${sample}.molecular.json"
+  echo $(locate_actin_blob reportGsutilUri "molecular json")
+}
+
+locate_actin_orange_json() {
+  local sample=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/orange/${sample}.orange.json"
+  echo $(locate_actin_blob reportGsutilUri "orange json")
+}
+
+locate_actin_orange_pdf() {
+  local sample=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/orange/${sample}.orange.pdf"
+  echo $(locate_actin_blob reportGsutilUri "orange pdf")
+}
+
+locate_actin_treatment_match_json() {
+  local patient=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_clinical_output_bucket}/algo/${patient}.treatment_match.json"
+  echo $(locate_actin_blob reportGsutilUri "treatment match json")
+}
+
+locate_actin_report_pdf() {
+  local patient=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/report/${patient}.actin.pdf"
+  echo $(locate_actin_blob reportGsutilUri "ACTIN report PDF")
+}
+
+locate_actin_evaluation_details() {
+  local patient=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/evaluation/${patient}.evaluation.details.tsv"
+  echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation details")
+}
+
+locate_actin_evaluation_summary() {
+  local patient=$1 && shift
+  local reportGsutilUri = "gs://${locate_actin_analysis_bucket}/evaluation/${patient}.evaluation.summary.tsv"
+  echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation summary")
+}
+
+################################# ACTIN Data VM Based ###################################
 
 locate_actin_curated_clinical_directory() {
     echo "/data/actin/clinical/curated"
 }
 
-locate_actin_clinical_json() {
-    local patient=$1 && shift
-    local clinical_dir=$(locate_actin_curated_clinical_directory)
-
-    if [[ ! -d "${clinical_dir}" ]]; then
-        error "Unable to locate ACTIN clinical directory '${clinical_dir}'"
-    fi
-
-    local clinical_json="${clinical_dir}/${patient}.clinical.json"
-    if [[ ! -f ${clinical_json} ]]; then
-        error "Could not locate clinical json for patient '${patient}'"
-    fi
-
-    echo "${clinical_json}"
-}
-
-locate_actin_clinical_json_for_sample() {
-    local sample=$1 && shift
-    local clinical_dir=$(locate_actin_curated_clinical_directory)
-
-    if [[ ! -d "${clinical_dir}" ]]; then
-        error "Unable to locate ACTIN clinical directory '${clinical_dir}'"
-    fi
-
-    patient=$(echo ${sample} | head -c 12)
-    local clinical_json="${clinical_dir}/${patient}.clinical.json"
-    if [[ ! -f ${clinical_json} ]]; then
-        error "Could not locate clinical json for patient '${patient}' based on sample '${sample}'"
-    fi
-
-    echo "${clinical_json}"
+locate_actin_clinical_input_feed_directory() {
+    echo "/data/actin/clinical/input_feed/latest"
 }
 
 locate_actin_wgs_pipeline_output_directory() {
@@ -517,100 +558,12 @@ locate_most_recent_actin_molecular_json() {
     echo $(locate_actin_molecular_json ${sample})
 }
 
-locate_actin_molecular_json() {
-    local sample=$1
-    local molecular_dir=$(locate_actin_molecular_directory_for_sample ${sample})
-
-    if [[ ! -d "${molecular_dir}" ]]; then
-        error "Unable to locate ACTIN molecular directory '${molecular_dir}'"
-    fi
-
-    local molecular_json="${molecular_dir}/actin/${sample}.molecular.json"
-    if [[ ! -f ${molecular_json} ]]; then
-        error "Could not locate molecular json for sample '${sample}'"
-    fi
-
-    echo "${molecular_json}"
-}
-
 locate_actin_trial_database_directory() {
     echo "/data/actin/trial_database"
 }
 
 locate_actin_treatment_match_directory() {
     echo "/data/actin/treatment_matches"
-}
-
-locate_actin_treatment_match_json() {
-    local patient=$1 && shift
-    local treatment_match_dir=$(locate_actin_treatment_match_directory)
-
-    if [[ ! -d "${treatment_match_dir}" ]]; then
-        error "Unable to locate ACTIN treatment match directory '${treatment_match_dir}'"
-    fi
-
-    local treatment_match_json="${treatment_match_dir}/${patient}.treatment_match.json"
-    if [[ ! -f ${treatment_match_json} ]]; then
-        error "Could not locate treatment match json for patient '${patient}'"
-    fi
-
-    echo "${treatment_match_json}"
-}
-
-locate_actin_reports_directory() {
-    echo "/data/actin/reports"
-}
-
-locate_actin_report_pdf() {
-    local patient=$1 && shift
-    local reports_dir=$(locate_actin_reports_directory)
-
-    if [[ ! -d "${reports_dir}" ]]; then
-        error "Unable to locate ACTIN report directory '${reports_dir}'"
-    fi
-
-    local report_pdf="${reports_dir}/${patient}.actin.pdf"
-    if [[ ! -f ${report_pdf} ]]; then
-        error "Could not locate ACTIN report pdf for patient '${patient}'"
-    fi
-
-    echo "${report_pdf}"
-}
-
-locate_actin_evaluation_directory() {
-    echo "/data/actin/evaluation"
-}
-
-locate_actin_evaluation_details() {
-    local patient=$1 && shift
-    local evaluation_dir=$(locate_actin_evaluation_directory)
-
-    if [[ ! -d "${evaluation_dir}" ]]; then
-        error "Unable to locate ACTIN evaluation directory '${evaluation_dir}'"
-    fi
-
-    local evaluation_details_tsv="${evaluation_dir}/${patient}.evaluation.details.tsv"
-    if [[ ! -f ${evaluation_details_tsv} ]]; then
-        error "Could not locate ACTIN evaluation details tsv for patient '${patient}'"
-    fi
-
-    echo "${evaluation_details_tsv}"
-}
-
-locate_actin_evaluation_summary() {
-    local patient=$1 && shift
-    local evaluation_dir=$(locate_actin_evaluation_directory)
-
-    if [[ ! -d "${evaluation_dir}" ]]; then
-        error "Unable to locate ACTIN evaluation directory '${evaluation_dir}'"
-    fi
-
-    local evaluation_summary_tsv="${evaluation_dir}/${patient}.evaluation.summary.tsv"
-    if [[ ! -f ${evaluation_summary_tsv} ]]; then
-        error "Could not locate ACTIN evaluation summary tsv for patient '${patient}'"
-    fi
-
-    echo "${evaluation_summary_tsv}"
 }
 
 ##################################### RNA ######################################

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -466,7 +466,7 @@ locate_actin_molecular_json() {
 
 locate_actin_orange_no_germline_json() {
   local sample=$1 && shift
-  local reportGsutilUri = "$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
+  local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
   echo $(locate_actin_blob reportGsutilUri "orange json")
 }
 

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -464,7 +464,7 @@ locate_actin_molecular_json() {
   echo $(locate_actin_blob reportGsutilUri "molecular json")
 }
 
-locate_actin_orange_no_germline__json() {
+locate_actin_orange_no_germline_json() {
   local sample=$1 && shift
   local reportGsutilUri = "$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
   echo $(locate_actin_blob reportGsutilUri "orange json")

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -439,8 +439,8 @@ locate_actin_analysis_bucket() {
 locate_actin_blob(){
   local gsutilUri=$1 && shift
   local name=$1 && shift
-  if gsutil ls "${reportGsutilUri}" >/dev/null 2>&1; then
-    echo "${reportGsutilUri}"
+  if gsutil ls "${gsutilUri}" >/dev/null 2>&1; then
+    echo "${gsutilUri}"
   else
     error "Could not locate ${name} at ${gsutilUri}"
   fi
@@ -449,7 +449,7 @@ locate_actin_blob(){
 locate_actin_clinical_json() {
   local patient=$1 && shift
   local reportGsutilUri="$(locate_actin_clinical_output_bucket)/${patient}.clinical.json"
-  echo $(locate_actin_blob reportGsutilUri "clinical json")
+  echo $(locate_actin_blob ${reportGsutilUri} "clinical json")
 }
 
 locate_actin_clinical_json_for_sample() {
@@ -461,43 +461,43 @@ locate_actin_clinical_json_for_sample() {
 locate_actin_molecular_json() {
   local sample=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)}/molecular/${sample}.molecular.json"
-  echo $(locate_actin_blob reportGsutilUri "molecular json")
+  echo $(locate_actin_blob ${reportGsutilUri} "molecular json")
 }
 
 locate_actin_orange_no_germline_json() {
   local sample=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
-  echo $(locate_actin_blob reportGsutilUri "orange json")
+  echo $(locate_actin_blob ${reportGsutilUri} "orange json")
 }
 
 locate_actin_orange_no_germline_pdf() {
   local sample=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
-  echo $(locate_actin_blob reportGsutilUri "orange pdf")
+  echo $(locate_actin_blob ${reportGsutilUri} "orange pdf")
 }
 
 locate_actin_treatment_match_json() {
   local patient=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/algo/${patient}.treatment_match.json"
-  echo $(locate_actin_blob reportGsutilUri "treatment match json")
+  echo $(locate_actin_blob ${reportGsutilUri} "treatment match json")
 }
 
 locate_actin_report_pdf() {
   local patient=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/report/${patient}.actin.pdf"
-  echo $(locate_actin_blob reportGsutilUri "ACTIN report PDF")
+  echo $(locate_actin_blob ${reportGsutilUri} "ACTIN report PDF")
 }
 
 locate_actin_evaluation_details() {
   local patient=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.details.tsv"
-  echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation details")
+  echo $(locate_actin_blob ${reportGsutilUri} "ACTIN evaluation details")
 }
 
 locate_actin_evaluation_summary() {
   local patient=$1 && shift
   local reportGsutilUri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.summary.tsv"
-  echo $(locate_actin_blob reportGsutilUri "ACTIN evaluation summary")
+  echo $(locate_actin_blob ${reportGsutilUri} "ACTIN evaluation summary")
 }
 
 ################################# ACTIN Data VM Based ###################################

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -434,80 +434,113 @@ locate_actin_analysis_bucket() {
   echo "gs://actin-prod-actin-analysis-output"
 }
 
-################################# ACTIN Data Bucket Based ###################################
+################################# ACTIN Data GCP ###################################
 
-locate_actin_blob(){
-  local gsutilUri=$1 && shift
+locate_actin_blob() {
+  local gsutil_uri=$1 && shift
   local name=$1 && shift
-  if gsutil ls "${gsutilUri}" >/dev/null 2>&1; then
-    echo "${gsutilUri}"
+  if gsutil ls "${gsutil_uri}" >/dev/null 2>&1; then
+    echo "${gsutil_uri}"
   else
-    error "Could not locate ${name} at ${gsutilUri}"
+    error "Could not locate ${name} at ${gsutil_uri}"
   fi
 }
 
-locate_actin_clinical_json() {
+locate_actin_clinical_json_gcp() {
   local patient=$1 && shift
-  local reportGsutilUri="$(locate_actin_clinical_output_bucket)/${patient}.clinical.json"
-  echo $(locate_actin_blob ${reportGsutilUri} "clinical json")
+  local report_gsutil_uri="$(locate_actin_clinical_output_bucket)/${patient}.clinical.json"
+  echo $(locate_actin_blob ${report_gsutil_uri} "clinical json")
 }
 
-locate_actin_clinical_json_for_sample() {
+locate_actin_clinical_json_for_sample_gcp() {
   local sample=$1 && shift
   patient=$(echo ${sample} | head -c 12)
   echo $(locate_actin_clinical_json ${patient})
 }
 
-locate_actin_molecular_json() {
+locate_actin_molecular_json_gcp() {
   local sample=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/molecular/${sample}.molecular.json"
-  echo $(locate_actin_blob ${reportGsutilUri} "molecular json")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/molecular/${sample}.molecular.json"
+  echo $(locate_actin_blob ${report_gsutil_uri} "molecular json")
 }
 
-locate_actin_orange_no_germline_json() {
+locate_actin_orange_no_germline_json_gcp() {
   local sample=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
-  echo $(locate_actin_blob ${reportGsutilUri} "orange json")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.json"
+  echo $(locate_actin_blob ${report_gsutil_uri} "orange json")
 }
 
-locate_actin_orange_no_germline_pdf() {
+locate_actin_orange_no_germline_pdf_gcp() {
   local sample=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
-  echo $(locate_actin_blob ${reportGsutilUri} "orange pdf")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/orange/${sample}.orange.pdf"
+  echo $(locate_actin_blob ${report_gsutil_uri} "orange pdf")
 }
 
-locate_actin_treatment_match_json() {
+locate_actin_treatment_match_json_gcp() {
   local patient=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/algo/${patient}.treatment_match.json"
-  echo $(locate_actin_blob ${reportGsutilUri} "treatment match json")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/algo/${patient}.treatment_match.json"
+  echo $(locate_actin_blob ${report_gsutil_uri} "treatment match json")
 }
 
-locate_actin_report_pdf() {
+locate_actin_report_pdf_gcp() {
   local patient=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/report/${patient}.actin.pdf"
-  echo $(locate_actin_blob ${reportGsutilUri} "ACTIN report PDF")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/report/${patient}.actin.pdf"
+  echo $(locate_actin_blob ${report_gsutil_uri} "ACTIN report PDF")
 }
 
-locate_actin_evaluation_details() {
+locate_actin_evaluation_details_gcp() {
   local patient=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.details.tsv"
-  echo $(locate_actin_blob ${reportGsutilUri} "ACTIN evaluation details")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.details.tsv"
+  echo $(locate_actin_blob ${report_gsutil_uri} "ACTIN evaluation details")
 }
 
-locate_actin_evaluation_summary() {
+locate_actin_evaluation_summary_gcp() {
   local patient=$1 && shift
-  local reportGsutilUri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.summary.tsv"
-  echo $(locate_actin_blob ${reportGsutilUri} "ACTIN evaluation summary")
+  local report_gsutil_uri="$(locate_actin_analysis_bucket)/evaluation/${patient}.evaluation.summary.tsv"
+  echo $(locate_actin_blob ${report_gsutil_uri} "ACTIN evaluation summary")
 }
 
 ################################# ACTIN Data VM Based ###################################
+
+locate_actin_clinical_input_feed_directory() {
+    echo "/data/actin/clinical/input_feed/latest"
+}
 
 locate_actin_curated_clinical_directory() {
     echo "/data/actin/clinical/curated"
 }
 
-locate_actin_clinical_input_feed_directory() {
-    echo "/data/actin/clinical/input_feed/latest"
+locate_actin_clinical_json() {
+    local patient=$1 && shift
+    local clinical_dir=$(locate_actin_curated_clinical_directory)
+
+    if [[ ! -d "${clinical_dir}" ]]; then
+        error "Unable to locate ACTIN clinical directory '${clinical_dir}'"
+    fi
+
+    local clinical_json="${clinical_dir}/${patient}.clinical.json"
+    if [[ ! -f ${clinical_json} ]]; then
+        error "Could not locate clinical json for patient '${patient}'"
+    fi
+
+    echo "${clinical_json}"
+}
+
+locate_actin_clinical_json_for_sample() {
+    local sample=$1 && shift
+    local clinical_dir=$(locate_actin_curated_clinical_directory)
+
+    if [[ ! -d "${clinical_dir}" ]]; then
+        error "Unable to locate ACTIN clinical directory '${clinical_dir}'"
+    fi
+
+    patient=$(echo ${sample} | head -c 12)
+    local clinical_json="${clinical_dir}/${patient}.clinical.json"
+    if [[ ! -f ${clinical_json} ]]; then
+        error "Could not locate clinical json for patient '${patient}' based on sample '${sample}'"
+    fi
+
+    echo "${clinical_json}"
 }
 
 locate_actin_wgs_pipeline_output_directory() {
@@ -558,6 +591,22 @@ locate_most_recent_actin_molecular_json() {
     echo $(locate_actin_molecular_json ${sample})
 }
 
+locate_actin_molecular_json() {
+    local sample=$1
+    local molecular_dir=$(locate_actin_molecular_directory_for_sample ${sample})
+
+    if [[ ! -d "${molecular_dir}" ]]; then
+        error "Unable to locate ACTIN molecular directory '${molecular_dir}'"
+    fi
+
+    local molecular_json="${molecular_dir}/actin/${sample}.molecular.json"
+    if [[ ! -f ${molecular_json} ]]; then
+        error "Could not locate molecular json for sample '${sample}'"
+    fi
+
+    echo "${molecular_json}"
+}
+
 locate_actin_trial_database_directory() {
     echo "/data/actin/trial_database"
 }
@@ -566,6 +615,77 @@ locate_actin_treatment_match_directory() {
     echo "/data/actin/treatment_matches"
 }
 
+locate_actin_treatment_match_json() {
+    local patient=$1 && shift
+    local treatment_match_dir=$(locate_actin_treatment_match_directory)
+
+    if [[ ! -d "${treatment_match_dir}" ]]; then
+        error "Unable to locate ACTIN treatment match directory '${treatment_match_dir}'"
+    fi
+
+    local treatment_match_json="${treatment_match_dir}/${patient}.treatment_match.json"
+    if [[ ! -f ${treatment_match_json} ]]; then
+        error "Could not locate treatment match json for patient '${patient}'"
+    fi
+
+    echo "${treatment_match_json}"
+}
+
+locate_actin_reports_directory() {
+    echo "/data/actin/reports"
+}
+
+locate_actin_report_pdf() {
+    local patient=$1 && shift
+    local reports_dir=$(locate_actin_reports_directory)
+
+    if [[ ! -d "${reports_dir}" ]]; then
+        error "Unable to locate ACTIN report directory '${reports_dir}'"
+    fi
+
+    local report_pdf="${reports_dir}/${patient}.actin.pdf"
+    if [[ ! -f ${report_pdf} ]]; then
+        error "Could not locate ACTIN report pdf for patient '${patient}'"
+    fi
+
+    echo "${report_pdf}"
+}
+
+locate_actin_evaluation_directory() {
+    echo "/data/actin/evaluation"
+}
+
+locate_actin_evaluation_details() {
+    local patient=$1 && shift
+    local evaluation_dir=$(locate_actin_evaluation_directory)
+
+    if [[ ! -d "${evaluation_dir}" ]]; then
+        error "Unable to locate ACTIN evaluation directory '${evaluation_dir}'"
+    fi
+
+    local evaluation_details_tsv="${evaluation_dir}/${patient}.evaluation.details.tsv"
+    if [[ ! -f ${evaluation_details_tsv} ]]; then
+        error "Could not locate ACTIN evaluation details tsv for patient '${patient}'"
+    fi
+
+    echo "${evaluation_details_tsv}"
+}
+
+locate_actin_evaluation_summary() {
+    local patient=$1 && shift
+    local evaluation_dir=$(locate_actin_evaluation_directory)
+
+    if [[ ! -d "${evaluation_dir}" ]]; then
+        error "Unable to locate ACTIN evaluation directory '${evaluation_dir}'"
+    fi
+
+    local evaluation_summary_tsv="${evaluation_dir}/${patient}.evaluation.summary.tsv"
+    if [[ ! -f ${evaluation_summary_tsv} ]]; then
+        error "Could not locate ACTIN evaluation summary tsv for patient '${patient}'"
+    fi
+
+    echo "${evaluation_summary_tsv}"
+}
 ##################################### RNA ######################################
 
 locate_rna_bam_directory() {


### PR DESCRIPTION
Adds locate functions to find all archived files in buckets rather than on VM filesystems.

@kduyvesteyn @spdeleeuw I think there is some redundancy between gs://actin-prod-patient-data, gs://actin-prod-evaluation, and gs://actin-prod-analysis-output. Can we consolidate to one bucket?

If the answer is yes, will probably abandon this PR and automate the archival on the GCP side. 