### PR TITLE
INFRA-235 Add LAMA hospitalSampleLabel to HMF-API reporting_id

### DIFF
--- a/lims/print_register_json.pl
+++ b/lims/print_register_json.pl
@@ -236,6 +236,9 @@ sub processSample{
     my $priority = getPriorityForSample( $sample );
     my $yield_in_gbase = getValueByKey( $sample, 'yield' );
     my $reporting_id = getValueByKey( $sample, 'reporting_id' );
+    if (exists $sample->{hospital_sample_label} and $sample->{hospital_sample_label} ne ""){
+        $reporting_id = $reporting_id . "-" . $sample->{hospital_sample_label};
+    }
     my $ref_reporting_id = $reporting_id . "-ref";
 
     ## floats are allowed for yield_in_gbase


### PR DESCRIPTION
When merged and deployed (git pull on ops-vm) this change will make it so that all samples that have a `hospitalSampleLabel` set in LAMA will get their `reporting_id` in HMF-API populated with: 
- tum sample = `{reportingId-from-patient}-{hospitalSampleLabel-from-tumor-sample}`
- ref sample = `{reportingId-from-patient}-{hospitalSampleLabel-from-tumor-sample}-ref` 