### PR TITLE
ACTIN-934 Parameterize sync scripts to support multiple projects

### DIFF
--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -17,8 +17,9 @@ gsutil -m rsync -r -d $(locate_actin_clinical_output_bucket $project) $(locate_a
 gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
 gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
 echo "gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)"
-gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)
-gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/molecular/ $(locate_actin_molecular_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/reports/ /data/actin/reports/
 gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
 
 info "Adding new actin pipeline outputs to treatment match (temporary)"

--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -3,26 +3,21 @@
 source message_functions || exit 1
 source locate_files || exit 1
 
-project=$1
-
 curr_host=$(hostname)
 if [[ "${curr_host}" == "prod-vm-operations" ]]; then
     error "ACTIN data is not supposed to synced to the prod VM"
 fi
 
 info "Syncing ACTIN patient data to local VM"
-gsutil -m rsync -r -d $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
-gsutil -m rsync -r -d $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
-gsutil -m rsync -r -d $(locate_actin_clinical_output_bucket $project) $(locate_actin_curated_clinical_directory)
-gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
-gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
-echo "gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)"
-gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/molecular/ $(locate_actin_molecular_directory)
-gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
-gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/reports/ /data/actin/reports/
-gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
+gsutil -m rsync -r $(locate_actin_clinical_feed_input_bucket) $(locate_actin_clinical_input_feed_directory)
+gsutil -m rsync -r $(locate_actin_clinical_curation_bucket) $(locate_actin_clinical_curation_directory)
+gsutil -m rsync -r $(locate_actin_clinical_output_bucket) $(locate_actin_curated_clinical_directory)
+gsutil -m rsync -r $(locate_actin_trial_config_bucket) $(locate_actin_trial_config_directory)
+gsutil -m rsync -r $(locate_actin_ctc_config_bucket) $(locate_actin_ctc_config_directory)
+gsutil -m rsync -r $(locate_actin_prod_data_bucket)/molecular/ $(locate_actin_molecular_directory)
+gsutil -m rsync -r $(locate_actin_prod_data_bucket)/treatment_match/ $(locate_actin_treatment_match_directory)
 
 info "Adding new actin pipeline outputs to treatment match (temporary)"
-gsutil cp -r $(locate_actin_analysis_bucket $project)/algo/* $(locate_actin_treatment_match_directory)
+gsutil cp -r $(locate_actin_analysis_bucket)/algo/* $(locate_actin_treatment_match_directory)
 
 info "Done"

--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -18,6 +18,7 @@ gsutil -m rsync -r $(locate_actin_trial_config_bucket $project) $(locate_actin_t
 gsutil -m rsync -r $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
 gsutil -m rsync -r $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)
 gsutil -m rsync -r $(locate_actin_prod_data_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
 
 info "Adding new actin pipeline outputs to treatment match (temporary)"
 gsutil cp -r $(locate_actin_analysis_bucket $project)/algo/* $(locate_actin_treatment_match_directory)

--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -16,6 +16,7 @@ gsutil -m rsync -r -d $(locate_actin_clinical_curation_bucket $project) $(locate
 gsutil -m rsync -r -d $(locate_actin_clinical_output_bucket $project) $(locate_actin_curated_clinical_directory)
 gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
 gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
+echo "gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)"
 gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)
 gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
 gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)

--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -11,14 +11,14 @@ if [[ "${curr_host}" == "prod-vm-operations" ]]; then
 fi
 
 info "Syncing ACTIN patient data to local VM"
-gsutil -m rsync -r $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
-gsutil -m rsync -r $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
-gsutil -m rsync -r $(locate_actin_clinical_output_bucket $project) $(locate_actin_curated_clinical_directory)
-gsutil -m rsync -r $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
-gsutil -m rsync -r $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
-gsutil -m rsync -r $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)
-gsutil -m rsync -r $(locate_actin_prod_data_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
-gsutil -m rsync -r $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_output_bucket $project) $(locate_actin_curated_clinical_directory)
+gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
+gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
+gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)
+gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
 
 info "Adding new actin pipeline outputs to treatment match (temporary)"
 gsutil cp -r $(locate_actin_analysis_bucket $project)/algo/* $(locate_actin_treatment_match_directory)

--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -3,21 +3,23 @@
 source message_functions || exit 1
 source locate_files || exit 1
 
+project=$1
+
 curr_host=$(hostname)
 if [[ "${curr_host}" == "prod-vm-operations" ]]; then
     error "ACTIN data is not supposed to synced to the prod VM"
 fi
 
 info "Syncing ACTIN patient data to local VM"
-gsutil -m rsync -r $(locate_actin_clinical_feed_input_bucket) $(locate_actin_clinical_input_feed_directory)
-gsutil -m rsync -r $(locate_actin_clinical_curation_bucket) $(locate_actin_clinical_curation_directory)
-gsutil -m rsync -r $(locate_actin_clinical_output_bucket) $(locate_actin_curated_clinical_directory)
-gsutil -m rsync -r $(locate_actin_trial_config_bucket) $(locate_actin_trial_config_directory)
-gsutil -m rsync -r $(locate_actin_ctc_config_bucket) $(locate_actin_ctc_config_directory)
-gsutil -m rsync -r $(locate_actin_prod_data_bucket)/molecular/ $(locate_actin_molecular_directory)
-gsutil -m rsync -r $(locate_actin_prod_data_bucket)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
+gsutil -m rsync -r $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
+gsutil -m rsync -r $(locate_actin_clinical_output_bucket $project) $(locate_actin_curated_clinical_directory)
+gsutil -m rsync -r $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
+gsutil -m rsync -r $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
+gsutil -m rsync -r $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)
+gsutil -m rsync -r $(locate_actin_prod_data_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
 
 info "Adding new actin pipeline outputs to treatment match (temporary)"
-gsutil cp -r $(locate_actin_analysis_bucket)/algo/* $(locate_actin_treatment_match_directory)
+gsutil cp -r $(locate_actin_analysis_bucket $project)/algo/* $(locate_actin_treatment_match_directory)
 
 info "Done"

--- a/actin/operational/sync_actin_data_to_vm
+++ b/actin/operational/sync_actin_data_to_vm
@@ -3,21 +3,26 @@
 source message_functions || exit 1
 source locate_files || exit 1
 
+project=$1
+
 curr_host=$(hostname)
 if [[ "${curr_host}" == "prod-vm-operations" ]]; then
     error "ACTIN data is not supposed to synced to the prod VM"
 fi
 
 info "Syncing ACTIN patient data to local VM"
-gsutil -m rsync -r $(locate_actin_clinical_feed_input_bucket) $(locate_actin_clinical_input_feed_directory)
-gsutil -m rsync -r $(locate_actin_clinical_curation_bucket) $(locate_actin_clinical_curation_directory)
-gsutil -m rsync -r $(locate_actin_clinical_output_bucket) $(locate_actin_curated_clinical_directory)
-gsutil -m rsync -r $(locate_actin_trial_config_bucket) $(locate_actin_trial_config_directory)
-gsutil -m rsync -r $(locate_actin_ctc_config_bucket) $(locate_actin_ctc_config_directory)
-gsutil -m rsync -r $(locate_actin_prod_data_bucket)/molecular/ $(locate_actin_molecular_directory)
-gsutil -m rsync -r $(locate_actin_prod_data_bucket)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_output_bucket $project) $(locate_actin_curated_clinical_directory)
+gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
+gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
+echo "gsutil -m rsync -r -d $(locate_actin_prod_data_bucket $project)/molecular/ $(locate_actin_molecular_directory)"
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/molecular/ $(locate_actin_molecular_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/reports/ /data/actin/reports/
+gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
 
 info "Adding new actin pipeline outputs to treatment match (temporary)"
-gsutil cp -r $(locate_actin_analysis_bucket)/algo/* $(locate_actin_treatment_match_directory)
+gsutil cp -r $(locate_actin_analysis_bucket $project)/algo/* $(locate_actin_treatment_match_directory)
 
 info "Done"

--- a/actin/operational/sync_actin_operations_vm
+++ b/actin/operational/sync_actin_operations_vm
@@ -5,21 +5,27 @@ source locate_files || exit 1
 
 set -e
 
-info "Syncing ACTIN wgs pipeline output"
-gsutil -m rsync -r -x ".*\.bam$|.*\.cram$" $(locate_actin_wgs_pipeline_bucket) $(locate_actin_wgs_pipeline_output_directory)
-gsutil -m rsync -r -d -x ".*\.bam$|.*\.cram$" gs://actin-prod-wgs-pipeline-output-diagnostic/ /data/actin/wgs_pipeline_output_diagnostic
+actin_prod_project_id="actin-prod"
+project={$1:-$actin_prod_project_id}
 
-info "Syncing ACTIN input data"
+info "Syncing ACTIN wgs pipeline output from GCP"
+gsutil -m rsync -r -x ".*\.bam$|.*\.cram$" $(locate_actin_wgs_pipeline_bucket $project) $(locate_actin_wgs_pipeline_output_directory)
+gsutil -m rsync -r -d -x ".*\.bam$|.*\.cram$" gs://$(project)-wgs-pipeline-output-diagnostic/ /data/actin/wgs_pipeline_output_diagnostic
+
+info "Syncing ACTIN input data from GCP"
 gsutil -m rsync -r -d $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
 gsutil -m rsync -r -d $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
 gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
 gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
 gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/molecular/ $(locate_actin_molecular_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
+gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/reports/ /data/actin/reports/
 
-info "Syncing ACTIN patient data"
+info "Syncing ACTIN patient data to GCP"
 gsutil -m rsync -r $(locate_actin_curated_clinical_directory) $(locate_actin_prod_data_bucket)/clinical/
-gsutil -m rsync -r -x "^(?!.*actin).*" $(locate_actin_molecular_directory) $(locate_actin_analysis_bucket)/molecular/
-gsutil -m rsync -r $(locate_actin_treatment_match_directory) $(locate_actin_analysis_bucket)/treatment_match/
-gsutil -m rsync -r $(locate_actin_reports_directory) $(locate_actin_analysis_bucket)/reports/
+gsutil -m rsync -r -x "^(?!.*actin).*" $(locate_actin_molecular_directory) $(locate_actin_prod_data_bucket)/molecular/
+gsutil -m rsync -r $(locate_actin_treatment_match_directory) $(locate_actin_prod_data_bucket)/treatment_match/
+
 
 info "Done"

--- a/actin/operational/sync_actin_operations_vm
+++ b/actin/operational/sync_actin_operations_vm
@@ -5,8 +5,7 @@ source locate_files || exit 1
 
 set -e
 
-actin_prod_project_id="actin-prod"
-project=${1:-$actin_prod_project_id}
+project=${1:-actin-prod}
 
 info "Syncing ACTIN wgs pipeline output from GCP"
 gsutil -m rsync -r -x ".*\.bam$|.*\.cram$" $(locate_actin_wgs_pipeline_bucket $project) $(locate_actin_wgs_pipeline_output_directory)
@@ -21,11 +20,5 @@ gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_ac
 gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/molecular/ $(locate_actin_molecular_directory)
 gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/treatment_match/ $(locate_actin_treatment_match_directory)
 gsutil -m rsync -r -d $(locate_actin_analysis_bucket $project)/reports/ /data/actin/reports/
-
-info "Syncing ACTIN patient data to GCP"
-gsutil -m rsync -r $(locate_actin_curated_clinical_directory) $(locate_actin_prod_data_bucket)/clinical/
-gsutil -m rsync -r -x "^(?!.*actin).*" $(locate_actin_molecular_directory) $(locate_actin_prod_data_bucket)/molecular/
-gsutil -m rsync -r $(locate_actin_treatment_match_directory) $(locate_actin_prod_data_bucket)/treatment_match/
-
 
 info "Done"

--- a/actin/operational/sync_actin_operations_vm
+++ b/actin/operational/sync_actin_operations_vm
@@ -6,7 +6,7 @@ source locate_files || exit 1
 set -e
 
 actin_prod_project_id="actin-prod"
-project={$1:-$actin_prod_project_id}
+project=${1:-$actin_prod_project_id}
 
 info "Syncing ACTIN wgs pipeline output from GCP"
 gsutil -m rsync -r -x ".*\.bam$|.*\.cram$" $(locate_actin_wgs_pipeline_bucket $project) $(locate_actin_wgs_pipeline_output_directory)

--- a/actin/operational/sync_actin_operations_vm
+++ b/actin/operational/sync_actin_operations_vm
@@ -9,9 +9,17 @@ info "Syncing ACTIN wgs pipeline output"
 gsutil -m rsync -r -x ".*\.bam$|.*\.cram$" $(locate_actin_wgs_pipeline_bucket) $(locate_actin_wgs_pipeline_output_directory)
 gsutil -m rsync -r -d -x ".*\.bam$|.*\.cram$" gs://actin-prod-wgs-pipeline-output-diagnostic/ /data/actin/wgs_pipeline_output_diagnostic
 
+info "Syncing ACTIN input data"
+gsutil -m rsync -r -d $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)
+gsutil -m rsync -r -d $(locate_actin_clinical_curation_bucket $project) $(locate_actin_clinical_curation_directory)
+gsutil -m rsync -r -d $(locate_actin_trial_config_bucket $project) $(locate_actin_trial_config_directory)
+gsutil -m rsync -r -d $(locate_actin_ctc_config_bucket $project) $(locate_actin_ctc_config_directory)
+gsutil -m rsync -r -d $(locate_actin_trial_database_bucket $project) $(locate_actin_trial_database_directory)
+
 info "Syncing ACTIN patient data"
 gsutil -m rsync -r $(locate_actin_curated_clinical_directory) $(locate_actin_prod_data_bucket)/clinical/
-gsutil -m rsync -r -x "^(?!.*actin).*" $(locate_actin_molecular_directory) $(locate_actin_prod_data_bucket)/molecular/
-gsutil -m rsync -r $(locate_actin_treatment_match_directory) $(locate_actin_prod_data_bucket)/treatment_match/
+gsutil -m rsync -r -x "^(?!.*actin).*" $(locate_actin_molecular_directory) $(locate_actin_analysis_bucket)/molecular/
+gsutil -m rsync -r $(locate_actin_treatment_match_directory) $(locate_actin_analysis_bucket)/treatment_match/
+gsutil -m rsync -r $(locate_actin_reports_directory) $(locate_actin_analysis_bucket)/reports/
 
 info "Done"

--- a/actin/operational/sync_actin_operations_vm
+++ b/actin/operational/sync_actin_operations_vm
@@ -10,7 +10,7 @@ project=${1:-$actin_prod_project_id}
 
 info "Syncing ACTIN wgs pipeline output from GCP"
 gsutil -m rsync -r -x ".*\.bam$|.*\.cram$" $(locate_actin_wgs_pipeline_bucket $project) $(locate_actin_wgs_pipeline_output_directory)
-gsutil -m rsync -r -d -x ".*\.bam$|.*\.cram$" gs://$(project)-wgs-pipeline-output-diagnostic/ /data/actin/wgs_pipeline_output_diagnostic
+gsutil -m rsync -r -d -x ".*\.bam$|.*\.cram$" gs://${project}-wgs-pipeline-output-diagnostic/ /data/actin/wgs_pipeline_output_diagnostic
 
 info "Syncing ACTIN input data from GCP"
 gsutil -m rsync -r -d $(locate_actin_clinical_feed_input_bucket $project) $(locate_actin_clinical_input_feed_directory)

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -473,6 +473,11 @@ locate_actin_analysis_bucket() {
     echo "gs://${project}-analysis-pipeline-output"
 }
 
+locate_actin_trial_database_bucket() {
+    project=${1:-actin-prod}
+    echo "gs://${project}-trial-pipeline-output"
+}
+
 ############################## ACTIN Data GCP ##################################
 
 locate_next_orange_shared_data_uri_gcp() {

--- a/functions/locate_files
+++ b/functions/locate_files
@@ -424,43 +424,53 @@ locate_actin_cohort_treatment_match_directory() {
 ############################### ACTIN Buckets ##################################
 
 locate_actin_clinical_data_feed_bucket() {
-    echo "gs://actin-prod-clinical-data-feed"
+    project=${1:-actin-prod}
+    echo "gs://${project}-clinical-data-feed"
 }
 
 locate_actin_clinical_feed_input_bucket() {
-    echo "gs://actin-prod-clinical-pipeline-feed-input"
+    project=${1:-actin-prod}
+    echo "gs://${project}-clinical-pipeline-feed-input"
 }
 
 locate_actin_clinical_curation_bucket() {
-    echo "gs://actin-prod-clinical-pipeline-curation-input"
+    project=${1:-actin-prod}
+    echo "gs://${project}-clinical-pipeline-curation-input"
 }
 
 locate_actin_clinical_output_bucket() {
-    echo "gs://actin-prod-clinical-pipeline-output"
+    project=${1:-actin-prod}
+    echo "gs://${project}-clinical-pipeline-output"
 }
 
 locate_actin_trial_config_bucket() {
-    echo "gs://actin-prod-trial-pipeline-trial-input"
+    project=${1:-actin-prod}
+    echo "gs://${project}-trial-pipeline-trial-input"
 }
 
 locate_actin_ctc_config_bucket() {
-    echo "gs://actin-prod-trial-pipeline-status-input"
+    project=${1:-actin-prod}
+    echo "gs://${project}-trial-pipeline-status-input"
 }
 
 locate_actin_shared_data_bucket() {
-    echo "gs://actin-prod-shared-data"
+    project=${1:-actin-prod}
+    echo "gs://${project}-shared-data"
 }
 
 locate_actin_wgs_pipeline_bucket() {
-    echo "gs://actin-prod-wgs-pipeline-output"
+    project=${1:-actin-prod}
+    echo "gs://${project}-wgs-pipeline-output"
 }
 
 locate_actin_prod_data_bucket() {
-    echo "gs://actin-prod-patient-data"
+    project=${1:-actin-prod}
+    echo "gs://${project}-patient-data"
 }
 
 locate_actin_analysis_bucket() {
-    echo "gs://actin-prod-analysis-pipeline-output"
+    project=${1:-actin-prod}
+    echo "gs://${project}-analysis-pipeline-output"
 }
 
 ############################## ACTIN Data GCP ##################################


### PR DESCRIPTION
Syncing (with rsync) the data automatically to these buckets will ensure we don't keep data past the retention period. 

This change parameterizes the locate_files bucket functions such that we can pass actin-nki to the same functions,
keeping actin-prod as default. 