### PR TITLE
INFRA-535 Add command to label disks after VM is created

### DIFF
--- a/gcp/make_vm
+++ b/gcp/make_vm
@@ -162,6 +162,7 @@ fi
 info "Start creating VM instance ${vm_name}"
 "${cmd[@]}" || die "Something went wrong with VM creation. Please check the gcloud response."
 echo ""
+gcloud compute disks add-labels "${vm_name}" --project="${vm_project}" --zone="${zone}" --labels="${labels}"
 
 info "Useful cmds:"
 echo " gcloud compute ssh ${vm_name} --tunnel-through-iap"


### PR DESCRIPTION
Labels can be added via a separate call to gcloud disks.