### PR TITLE
ACTIN-1107: Fetch personalization jar by build tag to current VM

### DIFF
--- a/actin/personalization/fetch_actin_personalization
+++ b/actin/personalization/fetch_actin_personalization
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+source message_functions || exit 1
+source locate_files || exit 1
+
+version=$1 && shift
+
+if [[ -z "${version}" ]]; then
+    error "Missing argument for version"
+fi
+
+destination=$(locate_actin_personalization_jar)
+info "Fetching personalization jar version ${version} to ${destination}"
+"$(dirname "$0")/fetch_tool_from_registry" personalization ${version} ${destination}

--- a/actin/personalization/fetch_tool_from_registry
+++ b/actin/personalization/fetch_tool_from_registry
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -ex
+
+function do_curl() {
+    # New versions (>7.52.1) of `curl` work properly with `--oauth2-bearer` instead of the explicit setting of a header
+    # At time of writing the imager VM was using this older version without prospect of upgrade
+    token="$(gcloud auth print-access-token)"
+    curl -H "authorization: Bearer ${token}" "$@"
+}
+
+AR_URL="https://europe-west4-maven.pkg.dev/actin-build/build-registry-maven/com/hartwig/actin"
+
+[[ $# -ne 3 ]] && echo "USAGE: $0 [tool name] [tool version] [destination path]" && exit 1
+
+tool=$1
+version=$2
+destination=$3
+
+remoteDir="${AR_URL}/${tool}/system/${version}"
+
+expected_md5="$(do_curl -o - -L "${remoteDir}/system-${version}.jar.md5")"
+do_curl -o "${destination}" -L "${remoteDir}/system-${version}.jar"
+actual_md5="$(md5sum "${destination}" | awk '{print $1}')"
+[[ $actual_md5 == "" ]] && echo "No local md5" && exit 1
+if [[ $actual_md5 != "$expected_md5" ]]; then
+    echo "Checksum not as expected or version not found in Artifact Registry for ${tool} version ${version}"
+    rm "${destination}"
+    exit 1
+else
+    echo "Fetched ${tool} version ${version} (md5=${actual_md5}) to ${destination}"
+fi

--- a/actin/personalization/fetch_tool_from_registry
+++ b/actin/personalization/fetch_tool_from_registry
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 function do_curl() {
     # New versions (>7.52.1) of `curl` work properly with `--oauth2-bearer` instead of the explicit setting of a header

--- a/actin/personalization/fetch_tool_from_registry
+++ b/actin/personalization/fetch_tool_from_registry
@@ -3,10 +3,7 @@
 set -e
 
 function do_curl() {
-    # New versions (>7.52.1) of `curl` work properly with `--oauth2-bearer` instead of the explicit setting of a header
-    # At time of writing the imager VM was using this older version without prospect of upgrade
-    token="$(gcloud auth print-access-token)"
-    curl -H "authorization: Bearer ${token}" "$@"
+    curl --oauth2-bearer "$(gcloud auth print-access-token)" "$@"
 }
 
 AR_URL="https://europe-west4-maven.pkg.dev/actin-build/build-registry-maven/com/hartwig/actin"
@@ -24,7 +21,7 @@ do_curl -o "${destination}" -L "${remoteDir}/system-${version}.jar"
 actual_md5="$(md5sum "${destination}" | awk '{print $1}')"
 [[ $actual_md5 == "" ]] && echo "No local md5" && exit 1
 if [[ $actual_md5 != "$expected_md5" ]]; then
-    echo "Checksum not as expected or version not found in Artifact Registry for ${tool} version ${version}"
+    echo "Checksum not as expected for ${tool} version ${version}"
     rm "${destination}"
     exit 1
 else


### PR DESCRIPTION
A much faster way to deploy a jar to a VM: run on the target VM to copy the jar from the artifact registry. Thanks to Ned and Paul for leading me here.