### PR TITLE
INFRA-755 fix clinical and DR view with missing treatments

### DIFF
--- a/sql/views/create_view_clinical.sql
+++ b/sql/views/create_view_clinical.sql
@@ -49,7 +49,7 @@ FROM sample
          LEFT JOIN (SELECT patientId, group_concat(doid separator ",") AS doids FROM doidNode GROUP BY 1) AS doidView
                    ON patient.id = doidView.patientId
          LEFT JOIN biopsy ON biopsy.sampleId = sample.sampleId
-         LEFT JOIN treatment ON treatment.biopsyId = biopsy.id
+         LEFT JOIN first_treatment_after_biopsy as treatment ON treatment.patientId = sample.patientId
          LEFT JOIN
      (SELECT treatment.biopsyId,
              GROUP_CONCAT(drug.type SEPARATOR '/')      AS treatmentType,

--- a/sql/views/create_view_datarequest_all.sql
+++ b/sql/views/create_view_datarequest_all.sql
@@ -56,7 +56,7 @@ FROM sample
          LEFT JOIN (SELECT patientId, group_concat(doid separator ",") AS doids FROM doidNode GROUP BY 1) AS doidView
                    ON sample.patientId = doidView.patientId
          LEFT JOIN biopsy ON biopsy.sampleId = sample.sampleId
-         LEFT JOIN treatment ON treatment.biopsyId = biopsy.id
+         LEFT JOIN first_treatment_after_biopsy as treatment ON treatment.patientId = sample.patientId
          LEFT JOIN
      (SELECT treatment.biopsyId,
              GROUP_CONCAT(drug.type SEPARATOR '/')      AS treatmentType,

--- a/sql/views/create_view_first_treatment_after_biopsy.sql
+++ b/sql/views/create_view_first_treatment_after_biopsy.sql
@@ -1,0 +1,16 @@
+create view first_treatment_after_biopsy as
+select treatment.*
+from treatment
+         join
+     -- If a patient has multiple treatments on the same day, we want to select the one with the lowest id
+         (select min(treatment.id) as id, treatment.patientId, treatment.startDate
+          from treatment
+                   -- If a patient has multiple biopsies, we want to select the one with the lowest treatment date
+                   join (select treatment.patientId, min(treatment.startDate) as startDate
+                         from treatment
+                                  left join biopsy on treatment.biopsyId = biopsy.id
+                         -- If a patient has a biopsy, filter out treatments that are before the biopsy
+                         where (biopsy.biopsyDate is null or biopsy.biopsyDate <= treatment.startDate)
+                         group by patientId) as firstDate
+                        on firstDate.patientId = treatment.patientId and firstDate.startDate = treatment.startDate
+          group by treatment.patientId, treatment.startDate) as firstId on firstId.id = treatment.id;


### PR DESCRIPTION
When a biopsy is not defined for a sample, but a treatment is, the clinical and datarequest views do not join the treatment because they join on the biopsy ID. This is the case for 239 CPCT samples and 138 WIDE samples. The fix is to join on the patient ID instead of the biopsy ID. The tricky thing about it is that we only want to join on the first treatment, but after the first biopsy, if it exists. To achieve this, I created the first treatment after biopsy view.

This workaround can be removed once the clinical biopsies are reworked and the data from LAMA is incorporated.