### PR TITLE
INFRA-865 Fix datarequest_all views in pilot, add pseudonymized version

### DIFF
--- a/sql/views/create_view_datarequest_all_pseudonymized.sql
+++ b/sql/views/create_view_datarequest_all_pseudonymized.sql
@@ -1,6 +1,7 @@
+# New datarequest_all view for the pseudonymized research database
 CREATE OR REPLACE VIEW datarequest_all AS
-SELECT amberAnonymous.hmfSampleId,
-       left(amberAnonymous.hmfSampleId, 9)      AS hmfPatientId,
+SELECT sample.sampleId                          AS hmfSampleId,
+       sample.donorId                           AS hmfPatientId,
        baseline.hospital,
        sample.cohortId,
        sample.sampleId,
@@ -53,7 +54,6 @@ FROM sample
 #          INNER JOIN metric ON sample.sampleId = metric.sampleId AND metric.sufficientCoverage = 0
 #        In production, use:
          INNER JOIN metric ON sample.sampleId = metric.sampleId AND metric.sufficientCoverage = 1
-         LEFT JOIN amberAnonymous on sample.sampleId = amberAnonymous.sampleId AND deleted = 0
          LEFT JOIN rnaStatistics on sample.sampleId = rnaStatistics.sampleId
          LEFT JOIN baseline ON specimen.patientId = baseline.patientId
          LEFT JOIN (SELECT patientId, group_concat(doid separator ',') AS doids FROM doidNode GROUP BY 1) AS doidView


### PR DESCRIPTION
Aligns the datarequest_all views with the migrations in clinical-db.
* Makes sure we use `metric.sufficientCoverage = 0` in pilot (I added that as comment in the clinical-db migrations, but that wasn't part of the definitions in the scripts repo). This was the reason the views in pilot did not show any data anymore.
* Adds a slightly different datarequest_all view for the pseudonymized database (which no longer uses amberAnonymous)

Having the datarequest views defined in two places is VERY confusing. Can we please choose one location (either the scripts repo or the clinical-db repo) and ONLY keep the datarequest views in there?