### PR TITLE
fix gcp key file

### DIFF
--- a/gcp/generate_signed_gcp_cram_url
+++ b/gcp/generate_signed_gcp_cram_url
@@ -2,6 +2,7 @@
 
 source api_functions || exit 1
 source message_functions || exit 1
+source secrets_functions || exit 1
 
 biopsy_name=$1 && shift # eg WIDE01010001T
 sample_type=$1 && shift # REF or TUM
@@ -41,15 +42,11 @@ fi
 [[ "${internal_cram_url}" =~ ^gs ]] || die "Internal URL has wrong format (${internal_cram_url}) for ${sample_type} sample of biopsy ${biopsy_name}"
 internal_crai_url="${internal_cram_url}.crai"
 
-# create a key file 
-key_file="$(mktemp)"
-exec {fd}<>${key_file}
-rm ${key_file}
-key_file=/dev/fd/$fd
-gcloud secrets versions access latest --secret=gcp-hmf-download-u-hmf-database --project=hmf-secrets > $key_file
+secret_name="gcp-hmf-download-u-hmf-database"
+credentials=$(get_secret_from_secret_manager "${secret_name}") || die "Unable to retrieve secret (${secret_name})"
 
-signed_cram_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_cram_url}" | grep -v 'Signed URL' | cut -f4)
-signed_crai_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_crai_url}" | grep -v 'Signed URL' | cut -f4)
+signed_cram_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" <(echo "${credentials}") "${internal_cram_url}" | grep -v 'Signed URL' | cut -f4)
+signed_crai_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" <(echo "${credentials}") "${internal_crai_url}" | grep -v 'Signed URL' | cut -f4)
 
 [[ "${signed_cram_url}" =~ ^https ]] || die "Signed URL has wrong format (${signed_cram_url})"
 [[ "${signed_crai_url}" =~ ^https ]] || die "Signed URL has wrong format (${signed_crai_url})"

--- a/gcp/generate_signed_gcp_cram_url
+++ b/gcp/generate_signed_gcp_cram_url
@@ -9,7 +9,6 @@ sample_type=$1 && shift # REF or TUM
 PRESIGN_SECONDS=172800
 PRESIGN_DAYS=$(expr "${PRESIGN_SECONDS}" / 60 / 60 / 24)
 
-key_file="/data/credentials/hmf-download"
 region="europe-west4"
 project="hmf-database"
 
@@ -41,6 +40,13 @@ fi
 # Sanity check (not all samples are linked to a biopsy yet in API)
 [[ "${internal_cram_url}" =~ ^gs ]] || die "Internal URL has wrong format (${internal_cram_url}) for ${sample_type} sample of biopsy ${biopsy_name}"
 internal_crai_url="${internal_cram_url}.crai"
+
+# create a key file 
+key_file="$(mktemp)"
+exec {fd}<>${key_file}
+rm ${key_file}
+key_file=/dev/fd/$fd
+gcloud secrets versions access latest --secret=gcp-hmf-download-u-hmf-database --project=hmf-secrets > $key_file
 
 signed_cram_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_cram_url}" | grep -v 'Signed URL' | cut -f4)
 signed_crai_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_crai_url}" | grep -v 'Signed URL' | cut -f4)

--- a/gcp/generate_signed_gcp_oncopanel_bam_url
+++ b/gcp/generate_signed_gcp_oncopanel_bam_url
@@ -8,7 +8,6 @@ biopsy_name=$1 && shift # eg TARGTO000000T
 PRESIGN_SECONDS=172800
 PRESIGN_DAYS=$(expr "${PRESIGN_SECONDS}" / 60 / 60 / 24)
 
-key_file="/data/credentials/hmf-download"
 region="europe-west4"
 project="hmf-database"
 
@@ -39,6 +38,13 @@ internal_bam_url="gs://${bucket}/${set_name}/${biopsy_name}/aligner/${biopsy_nam
 # Sanity check (not all samples are linked to a biopsy yet in API)
 [[ "${internal_bam_url}" =~ ^gs ]] || die "Internal URL has wrong format (${internal_bam_url}) for biopsy ${biopsy_name}"
 internal_bai_url="${internal_bam_url}.bai"
+
+# generate key file
+key_file="$(mktemp)"
+exec {fd}<>${key_file}
+rm ${key_file}
+key_file=/dev/fd/$fd
+gcloud secrets versions access latest --secret=gcp-hmf-download-u-hmf-database --project=hmf-secrets > $key_file
 
 signed_bam_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bam_url}" | grep -v 'Signed URL' | cut -f4)
 signed_bai_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bai_url}" | grep -v 'Signed URL' | cut -f4)

--- a/gcp/generate_signed_gcp_oncopanel_bam_url
+++ b/gcp/generate_signed_gcp_oncopanel_bam_url
@@ -2,6 +2,7 @@
 
 source api_functions || exit 1
 source message_functions || exit 1
+source secrets_functions || exit 1
 
 biopsy_name=$1 && shift # eg TARGTO000000T
 
@@ -39,15 +40,11 @@ internal_bam_url="gs://${bucket}/${set_name}/${biopsy_name}/aligner/${biopsy_nam
 [[ "${internal_bam_url}" =~ ^gs ]] || die "Internal URL has wrong format (${internal_bam_url}) for biopsy ${biopsy_name}"
 internal_bai_url="${internal_bam_url}.bai"
 
-# generate key file
-key_file="$(mktemp)"
-exec {fd}<>${key_file}
-rm ${key_file}
-key_file=/dev/fd/$fd
-gcloud secrets versions access latest --secret=gcp-hmf-download-u-hmf-database --project=hmf-secrets > $key_file
+secret_name="gcp-hmf-download-u-hmf-database"
+credentials=$(get_secret_from_secret_manager "${secret_name}") || die "Unable to retrieve secret (${secret_name})"
 
-signed_bam_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bam_url}" | grep -v 'Signed URL' | cut -f4)
-signed_bai_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bai_url}" | grep -v 'Signed URL' | cut -f4)
+signed_bam_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" <(echo "${credentials}") "${internal_bam_url}" | grep -v 'Signed URL' | cut -f4)
+signed_bai_url=$(gsutil signurl -r "${region}" -b "${project}" -d "${PRESIGN_SECONDS}s" <(echo "${credentials}") "${internal_bai_url}" | grep -v 'Signed URL' | cut -f4)
 
 [[ "${signed_bam_url}" =~ ^https ]] || die "Signed URL has wrong format (${signed_bam_url})"
 [[ "${signed_bai_url}" =~ ^https ]] || die "Signed URL has wrong format (${signed_bai_url})"

--- a/gcp/generate_signed_gcp_rna_bam_url
+++ b/gcp/generate_signed_gcp_rna_bam_url
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source message_functions || exit 1
+source secrets_functions || exit 1
 
 sampleId=$1 && shift # tumor sample ID
 
@@ -38,15 +39,11 @@ print_usage(){
           die "Bai file is not present at expected location in bucket. Exiting."
     fi
 
-# generate key file
-key_file="$(mktemp)"
-exec {fd}<>${key_file}
-rm ${key_file}
-key_file=/dev/fd/$fd
-gcloud secrets versions access latest --secret=gcp-hmf-download-u-hmf-database --project=hmf-secrets > $key_file
+secret_name="gcp-hmf-download-u-hmf-database"
+credentials=$(get_secret_from_secret_manager "${secret_name}") || die "Unable to retrieve secret (${secret_name})"
 
-signed_bam_url=$(gsutil signurl -r "${region}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bam_url}")
-signed_bai_url=$(gsutil signurl -r "${region}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bai_url}")
+signed_bam_url=$(gsutil signurl -r "${region}" -d "${PRESIGN_SECONDS}s" <(echo "${credentials}") "${internal_bam_url}")
+signed_bai_url=$(gsutil signurl -r "${region}" -d "${PRESIGN_SECONDS}s" <(echo "${credentials}") "${internal_bai_url}")
 
 info "URLs for sample ID ${sampleId} (valid for ${PRESIGN_SECONDS} seconds or ${PRESIGN_DAYS} days):"
 

--- a/gcp/generate_signed_gcp_rna_bam_url
+++ b/gcp/generate_signed_gcp_rna_bam_url
@@ -7,7 +7,6 @@ sampleId=$1 && shift # tumor sample ID
 PRESIGN_SECONDS=172800
 PRESIGN_DAYS=$(expr "${PRESIGN_SECONDS}" / 60 / 60 / 24)
 
-key_file="/data/credentials/hmf-download"
 region="europe-west4"
 internal_bam_url="gs://hmf-rna-analysis/samples/${sampleId}/${sampleId}.sorted.dups.bam"
 internal_bai_url="gs://hmf-rna-analysis/samples/${sampleId}/${sampleId}.sorted.dups.bam.bai"
@@ -38,6 +37,13 @@ print_usage(){
         warn "Unable to locate bam.bai file in bucket (URL='${internal_bai_url})"
           die "Bai file is not present at expected location in bucket. Exiting."
     fi
+
+# generate key file
+key_file="$(mktemp)"
+exec {fd}<>${key_file}
+rm ${key_file}
+key_file=/dev/fd/$fd
+gcloud secrets versions access latest --secret=gcp-hmf-download-u-hmf-database --project=hmf-secrets > $key_file
 
 signed_bam_url=$(gsutil signurl -r "${region}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bam_url}")
 signed_bai_url=$(gsutil signurl -r "${region}" -d "${PRESIGN_SECONDS}s" "${key_file}" "${internal_bai_url}")


### PR DESCRIPTION
Gcp key file was removed from data-vm-prod-2. This is to generate it on demand. Not sure if it is good idea?