### PR TITLE
ACTIN-3606 Correct topic for shared pubsub

### DIFF
--- a/actin/local/operational/share_actin_data_and_report_with_emc
+++ b/actin/local/operational/share_actin_data_and_report_with_emc
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 source locate_files || exit 1
 source message_functions || exit 1
 source actin_config || exit 1
@@ -25,7 +24,6 @@ if [[ "${sync_orange}" != "true" && "${sync_orange}" != "false" ]]; then
 fi
 
 gcp_project=$(production_actin_emc_project)
-
 shared_actin_data_external_uri="$(locate_next_actin_shared_data_external_uri_gcp "${gcp_project}" "${patient}" "${namespace}")"
 
 actin_report_pdf="$(locate_actin_report_pdf_gcp "${gcp_project}" "${patient}" "${namespace}")"

--- a/actin/local/operational/share_actin_data_and_report_with_emc
+++ b/actin/local/operational/share_actin_data_and_report_with_emc
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+
 source locate_files || exit 1
 source message_functions || exit 1
 source actin_config || exit 1
@@ -24,6 +25,7 @@ if [[ "${sync_orange}" != "true" && "${sync_orange}" != "false" ]]; then
 fi
 
 gcp_project=$(production_actin_emc_project)
+
 shared_actin_data_external_uri="$(locate_next_actin_shared_data_external_uri_gcp "${gcp_project}" "${patient}" "${namespace}")"
 
 actin_report_pdf="$(locate_actin_report_pdf_gcp "${gcp_project}" "${patient}" "${namespace}")"
@@ -42,7 +44,7 @@ gsutil cp "${actin_report_pdf}" "${shared_actin_data_external_uri}/"
 write_shared_data_latest_path_manifest "${shared_actin_data_external_uri}"
 
 info "Tracking report shared event for ${patient}"
-gcloud pubsub topics publish "projects/${gcp_project}/topics/patient-tracker.${namespace}.update" \
+gcloud pubsub topics publish "projects/actin-shared/topics/patient-tracker.update" \
     --message="{\"patientId\":\"${patient}\",\"site\":\"${gcp_project}\",\"namespace\":\"${namespace}\",\"timestamp\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",\"process\":\"SHARING\",\"status\":\"SHARED\",\"message\":null}"
 
 if [[ "${sync_orange}" == "false" ]]; then

--- a/actin/local/operational/share_actin_data_and_report_with_nki
+++ b/actin/local/operational/share_actin_data_and_report_with_nki
@@ -34,6 +34,6 @@ write_shared_data_latest_path_manifest "${shared_actin_data_external_uri}"
 echo "Copied files to ${shared_actin_data_external_uri}"
 
 info "Tracking report shared event for ${patient}"
-gcloud pubsub topics publish "projects/${gcp_project}/topics/patient-tracker.update" \
+gcloud pubsub topics publish "projects/actin-shared/topics/patient-tracker.update" \
     --message="{\"patientId\":\"${patient}\",\"site\":\"${gcp_project}\",\"timestamp\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",\"process\":\"SHARING\",\"status\":\"SHARED\",\"message\":null}"
 


### PR DESCRIPTION
The project should be the shared one. For EMC John already changed the payload to include the namespace.

The topics currently exist in the per-hospital projects too, which is probably a holdover from version 0. Expect a related PR in the infrastructure project to correct that.

Confirmed this works to update the share time with the EMC script by commenting out all of the operations bar the pubsub publish.
