### PR TITLE
ACTIN-3639 Use DNS instead of bastion proxy

### DIFF
--- a/actin/local/operational/manage_tunnel.sh
+++ b/actin/local/operational/manage_tunnel.sh
@@ -29,8 +29,9 @@ gcloud container clusters get-credentials "${clusters[$env]}" --zone europe-west
 
 pod="$(kubectl -n "$ns" get pods | grep "^${apps[$app]}-" | awk '{print $1}' | tail -n1)"
 [[ -z "$pod" ]] && echo "No pod found for application '$app'" && exit 1
-port="${ports[$app]}"
-
-(sleep 3; open "http://localhost:$port/${paths[$app]}" ) &
-kubectl -n "$ns" port-forward "pod/${pod}" "$port:$port"
-
+remote="${ports[$app]}"
+increment=0
+[[ $env == "research" ]] && increment=1000
+local="$(( $remote + $increment ))"
+(sleep 3; open "http://localhost:$local/${paths[$app]}" ) &
+kubectl -n "$ns" port-forward "pod/${pod}" "$local:$remote"

--- a/actin/local/operational/manage_tunnel.sh
+++ b/actin/local/operational/manage_tunnel.sh
@@ -9,6 +9,9 @@ function print_usage() {
 
 [[ $# -ne 2 && $# -ne 3 ]] && print_usage && exit 1
 
+gcv="$(gcloud --version | head -n1 | awk '{print $NF}' | awk -F. '{print $1}')"
+[[ $gcv -lt "496" ]] && echo "Local version of gcloud is not new enough (need >= 496.0.0)" && exit 1
+
 env="$1"
 app="$2"
 ns="${3:-default}"

--- a/actin/local/operational/manage_tunnel.sh
+++ b/actin/local/operational/manage_tunnel.sh
@@ -1,140 +1,34 @@
 #!/usr/bin/env bash
 
-REMOTE_TUNNEL_PORT=8080
-KUBE_PORT=8888
-CONFIG_DIR="$(readlink -f "$(dirname "$0")")/.tunnel_configurations"
-
-function print_available_configs() {
-    echo "Known configurations:"
-    for c in "$(ls $CONFIG_DIR)"; do
-        echo "${c}" | sed -e 's/^/  /' -e 's/\.config$//'
-    done
+function print_usage() {
+  echo "$0: establish a connection to an application running in Kubernetes"
+  echo "Use one of these forms:"
+  echo "  $0 prod [app]"
+  echo "  $0 research [app] [namespace]"
 }
 
-function cleanup() {
-    echo "Stopping all tunnels to bastion VMs.  This script does not support multiple tunnels running on one local machine."
-    ps aux | grep "bastion" | grep 'start-iap-tunnel' | awk '{print $2}' | while read pid; do
-        [[ -n $pid ]] && kill $pid 
-        echo "  Process [$pid] killed"
-    done
-    echo "Cleanup complete"
-}
+[[ $# -ne 2 && $# -ne 3 ]] && print_usage && exit 1
 
-function k8() {
-    port=$1 && shift 
-    HTTPS_PROXY=localhost:$port kubectl $@
-}
+env="$1"
+app="$2"
+ns="${3:-default}"
 
-function start_remote_proxy() {
-    local gc_cli="$1"
-    local instance="$2"
-    local zone="$3"
-    local namespace="$4"
-    local project="$5"
-    local cluster="$6"
-    local services="$7"
+[[ "$env" != "research" && "$env" != "prod" ]] && print_usage && exit 1
+[[ "$env" == "prod" && "$ns" != "default" ]] && print_usage && exit 1
+[[ "$env" == "research" && "$ns" == "default" ]] && echo "Warning: namespace '$ns' given for research, could be a problem"
 
-    local remote_script
-    remote_script=$(cat <<EOF
-set -euo pipefail
-LOG_FILE="\${HOME}/actin-ui-proxy.log"
-PORT_LINE=""
+declare -A clusters=( ["research"]="research-cluster-patient-processing" ["prod"]="shared-cluster-services" )
+declare -A projects=( ["research"]="actin-research" ["prod"]="actin-shared" )
+declare -A apps=( ["trial-ui"]="actin-trial-ui" ["tracker-ui"]="actin-patient-tracker" ["feed-review"]="actin-feed-review" )
+declare -A ports=( ["trial-ui"]="8082" ["tracker-ui"]="9999" ["feed-review"]="9999" )
 
-get_port_line() {
-    (grep "PROXY_PORT=" "\${LOG_FILE}" 2>/dev/null || true) | tail -n1
-}
+set -e
 
-mkdir -p "\$(dirname "\${LOG_FILE}")"
-[[ -f "\${LOG_FILE}" ]] || : > "\${LOG_FILE}"
-PORT_LINE=\$(get_port_line)
+gcloud container clusters get-credentials "${clusters[$env]}" --zone europe-west4 --project "${projects[$env]}" --dns-endpoint
 
-if [[ -z "\${PORT_LINE}" ]]; then
-    echo "Starting actin-ui-proxy for \${USER}"
-    nohup actin-ui-proxy $project $namespace $cluster $services >> "\${LOG_FILE}" 2>&1 &
-    for _ in \$(seq 1 30); do
-        PORT_LINE=\$(get_port_line)
-        if [[ -n "\${PORT_LINE}" ]]; then
-            break
-        fi
-        sleep 1
-    done
-else
-    echo "Found existing PROXY_PORT entry in \${LOG_FILE}; reusing running proxy"
-fi
+pod="$(kubectl -n "$ns" get pods | grep "^${apps[$app]}-" | awk '{print $1}' | tail -n1)"
+[[ -z "$pod" ]] && echo "No pod found for application '$app'" && exit 1
+port="${ports[$app]}"
 
-if [[ -z "\${PORT_LINE}" ]]; then
-    echo "Failed to find PROXY_PORT in \${LOG_FILE}" >&2
-    exit 1
-fi
+kubectl -n "$ns" port-forward "pod/${pod}" "$port:$port"
 
-echo "\${PORT_LINE}"
-EOF
-)
-
-    local proxy_output remote_port
-    proxy_output=$($gc_cli ssh "$instance" --tunnel-through-iap --zone "$zone" --command "bash -lc '$remote_script'")
-    remote_port=$(echo "$proxy_output" | awk -F= '/PROXY_PORT=/{print $2; exit}')
-    if [[ -z "$remote_port" ]]; then
-        echo "Unable to determine remote proxy port from actin-ui-proxy output" >&2
-        echo "$proxy_output" >&2
-        exit 1
-    fi
-
-    echo "$proxy_output" >&2
-    echo "$remote_port"
-}
-
-
-function usage() {
-    cat<<EOM
-    
-USAGE: $0 stop [local port] 
-       $0 start (config name) [local port]
-
-  start|stop  - Action to perform
-  config name - Configuration file to read, see below for existing list
-  local port  - Optional local port number to use for the tunnel to avoid conflicts
-
-EOM
-
-  print_available_configs
-}
-
-[[ $# -gt 3 ]] && usage && exit 1
-
-cleanup
-
-action="$1"
-if [[ $action == "stop" ]]; then
-    echo "Tunnels stopped"
-elif [[ $action == "start" ]]; then
-    [[ $# -ne 2 && $# -ne 3 ]] && usage && exit 1
-    config_file="${CONFIG_DIR}/${2}.config"
-    [[ ! -f $config_file ]] && echo "Unknown configuration \"$1\": no file [$(basename ${config_file})] in [${CONFIG_DIR}]" && print_available_configs && exit 1
-
-    source $config_file
-
-    for var in PROJECT BASTION PORT CONTEXT_ROOT CLUSTER NAMESPACE; do
-        [[ -z ${!var} ]] && echo "$var must be specified in [$config_file]" && exit 1
-    done
-
-    GC="gcloud --project $PROJECT compute"
-    echo "Attempting to determine name of bastion VM"
-    read instance zone <<< $($GC instances list | grep $BASTION | head -n1 | awk '{print $1, $2}')
-    [[ -z $instance || -z $zone ]] && echo "Cannot locate bastion VM instance" && exit 1
-    ps aux | grep gcloud | grep ssh | grep -- "$instance" >/dev/null
-    if [[ $? -ne 0 ]]; then
-        REMOTE_PROXY_PORT=$(start_remote_proxy "$GC" "$instance" "$zone" "$NAMESPACE" "$PROJECT" "$CLUSTER" "$CONTEXT_ROOT")
-        echo "Using bastion proxy on port $REMOTE_PROXY_PORT"
-        $GC ssh $instance --tunnel-through-iap --zone $zone -- -L "$PORT:localhost:$REMOTE_PROXY_PORT" -L "$KUBE_PORT:localhost:$KUBE_PORT" -N -q -f
-    else 
-        echo "Re-using existing SSH tunnel to bastion"
-    fi
-    link="http://localhost:$PORT/$CONTEXT_ROOT"
-    echo "Tunnel started; access $2 at: $link. Opening..."
-    open "$link"
-else
-    echo "Unknown action \"$action\""
-    usage
-    exit 1
-fi

--- a/actin/local/operational/manage_tunnel.sh
+++ b/actin/local/operational/manage_tunnel.sh
@@ -21,6 +21,7 @@ declare -A clusters=( ["research"]="research-cluster-patient-processing" ["prod"
 declare -A projects=( ["research"]="actin-research" ["prod"]="actin-shared" )
 declare -A apps=( ["trial-ui"]="actin-trial-ui" ["tracker-ui"]="actin-patient-tracker" ["feed-review"]="actin-feed-review" )
 declare -A ports=( ["trial-ui"]="8082" ["tracker-ui"]="9999" ["feed-review"]="9999" )
+declare -A paths=( ["trial-ui"]="trial-ui" ["tracker-ui"]="" ["feed-review"]="" )
 
 set -e
 
@@ -30,5 +31,6 @@ pod="$(kubectl -n "$ns" get pods | grep "^${apps[$app]}-" | awk '{print $1}' | t
 [[ -z "$pod" ]] && echo "No pod found for application '$app'" && exit 1
 port="${ports[$app]}"
 
+(sleep 3; open "http://localhost:$port/${paths[$app]}" ) &
 kubectl -n "$ns" port-forward "pod/${pod}" "$port:$port"
 

--- a/actin/local/operational/manage_tunnel.sh
+++ b/actin/local/operational/manage_tunnel.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 
 function print_usage() {
   echo "$0: establish a connection to an application running in Kubernetes"
@@ -32,5 +32,6 @@ remote="${ports[$app]}"
 increment=0
 [[ $env == "research" ]] && increment=1000
 local="$(( $remote + $increment ))"
-(sleep 3; open "http://localhost:$local/$app" ) &
+username="$(gcloud compute os-login describe-profile --format="json" | jq -r '.posixAccounts[].username')"
+(sleep 3; open "http://localhost:$local/${app}?username=${username}" ) &
 kubectl -n "$ns" port-forward "pod/${pod}" "$local:$remote"

--- a/actin/local/operational/manage_tunnel.sh
+++ b/actin/local/operational/manage_tunnel.sh
@@ -20,8 +20,7 @@ ns="${3:-default}"
 declare -A clusters=( ["research"]="research-cluster-patient-processing" ["prod"]="shared-cluster-services" )
 declare -A projects=( ["research"]="actin-research" ["prod"]="actin-shared" )
 declare -A apps=( ["trial-ui"]="actin-trial-ui" ["tracker-ui"]="actin-patient-tracker" ["feed-review"]="actin-feed-review" )
-declare -A ports=( ["trial-ui"]="8082" ["tracker-ui"]="9999" ["feed-review"]="9999" )
-declare -A paths=( ["trial-ui"]="trial-ui" ["tracker-ui"]="" ["feed-review"]="" )
+declare -A ports=( ["trial-ui"]="8082" ["tracker-ui"]="8085" ["feed-review"]="8080" )
 
 set -e
 
@@ -33,5 +32,5 @@ remote="${ports[$app]}"
 increment=0
 [[ $env == "research" ]] && increment=1000
 local="$(( $remote + $increment ))"
-(sleep 3; open "http://localhost:$local/${paths[$app]}" ) &
+(sleep 3; open "http://localhost:$local/$app" ) &
 kubectl -n "$ns" port-forward "pod/${pod}" "$local:$remote"

--- a/actin/local/operational/start_tunnel.sh
+++ b/actin/local/operational/start_tunnel.sh
@@ -37,4 +37,5 @@ increment=0
 local="$(( $remote + $increment ))"
 username="$(gcloud compute os-login describe-profile --format="json" | jq -r '.posixAccounts[].username')"
 (sleep 3; open "http://localhost:$local/${app}?username=${username}" ) &
+echo "Establishing tunnel, Ctrl-C will close it"
 kubectl -n "$ns" port-forward "pod/${pod}" "$local:$remote"


### PR DESCRIPTION
This change requires enabling the DNS endpoint on the cluster, but once that's there we no longer require the proxying via the bastion.

Some explanation: Charlotte was having problems connecting to the patient tracker today, and I felt more like trying to improve the situation than band-aiding the bastion setup again.

I've tested this works in the research environment for the trial UI, patient tracker and the clinical review applications.

Also with this change I think we can remove the pathing from the applications, I think it was really only needed to accommodate the bastion's proxying configuration. Maybe for the moment I can put a redirect as the original script had.